### PR TITLE
fixes and improvements up to OL snapshot-20221031

### DIFF
--- a/conf/opts.ts
+++ b/conf/opts.ts
@@ -6,3 +6,4 @@
 --script=scripts/disable_unused_agts
 --script=scripts/export_driver_sources
 --script=scripts/check_bpf
+--tester-script=scripts/os-trc-tags

--- a/net-drv-ts/basic/multicast.c
+++ b/net-drv-ts/basic/multicast.c
@@ -32,6 +32,14 @@
 
 #include "net_drv_test.h"
 
+/*
+ * Allowed number of lost packets to pass with verdict.
+ *
+ * Running on Intel X710 (intel/i40e driver) requires up to 1 second
+ * for multicast traffic to work after join.
+ */
+#define TEST_ALLOWED_PKT_LOSS   TE_DIV_ROUND_UP(1000, TAPI_WAIT_NETWORK_DELAY)
+
 int
 main(int argc, char *argv[])
 {
@@ -59,6 +67,9 @@ main(int argc, char *argv[])
 
     te_bool tx;
     int sends_num;
+    size_t len;
+    size_t total_len = 0;
+    unsigned int lost = 0;
 
     TEST_START;
     TEST_GET_PCO(iut_rpcs);
@@ -133,11 +144,26 @@ main(int argc, char *argv[])
     TEST_STEP("For @p sends_num times, send a packet from the sender "
               "socket to @p mcast_addr, receive and check it on "
               "the receiver.");
-    for (i = 0; i < sends_num; i++)
+    for (total_len = 0, lost = 0, i = 0; i < sends_num; i++, total_len += len)
     {
-        net_drv_sendto_recv_check(sender_rpcs, sender_s, mcast_addr,
-                                  receiver_rpcs, receiver_s,
-                                  "Checking multicast sending");
+        len = net_drv_sendto_recv_check_may_loss(sender_rpcs, sender_s,
+                                                 mcast_addr,
+                                                 receiver_rpcs, receiver_s,
+                                                 "Checking multicast sending");
+        if (len == 0)
+        {
+            lost++;
+            /* Do not allow loss after successfully send/received packet */
+            if (total_len != 0)
+                TEST_VERDICT("Sent multicast packet is not received");
+        }
+    }
+    if (lost > 0)
+    {
+        if (total_len > 0 && lost <= TEST_ALLOWED_PKT_LOSS)
+            WARN_VERDICT("Few leading multicast packets are not received");
+        else
+            TEST_VERDICT("Too many leading multicast packets are not received");
     }
 
     TEST_SUCCESS;

--- a/net-drv-ts/basic/multicast.c
+++ b/net-drv-ts/basic/multicast.c
@@ -161,7 +161,7 @@ main(int argc, char *argv[])
     if (lost > 0)
     {
         if (total_len > 0 && lost <= TEST_ALLOWED_PKT_LOSS)
-            WARN_VERDICT("Few leading multicast packets are not received");
+            WARN("Few leading multicast packets are not received");
         else
             TEST_VERDICT("Too many leading multicast packets are not received");
     }

--- a/net-drv-ts/lib/net_drv_ptp.h
+++ b/net-drv-ts/lib/net_drv_ptp.h
@@ -42,9 +42,10 @@
  * @param rpcs      RPC server
  * @param if_name   Interface name
  * @param fd        Where to save opened file descriptor
+ * @param vpref     Prefix for verdicts (may be @c NULL or empty)
  */
 extern void net_drv_open_ptp_fd(rcf_rpc_server *rpcs, const char *if_name,
-                                int *fd);
+                                int *fd, const char *vpref);
 
 /**
  * Get difference between two timespec structures in seconds

--- a/net-drv-ts/lib/net_drv_ts.c
+++ b/net-drv-ts/lib/net_drv_ts.c
@@ -311,7 +311,7 @@ net_drv_sendto_recv_check_gen(rcf_rpc_server *rpcs_sender,
                          vpref, RPC_ERROR_ARGS(rpcs_receiver));
         }
         total_len += rc;
-        if (total_len >= MAX_PKT_LEN)
+        if (total_len >= len)
             break;
         RPC_GET_READABILITY(readable, rpcs_receiver, s_receiver,
                             TAPI_WAIT_NETWORK_DELAY);

--- a/net-drv-ts/lib/net_drv_ts.c
+++ b/net-drv-ts/lib/net_drv_ts.c
@@ -75,9 +75,23 @@ net_drv_driver_set_loaded(const char *ta,
     cfg_val_type cvt_int = CVT_INTEGER;
 
     if (load)
+    {
         rc = tapi_cfg_module_load(ta, module);
+    }
     else
+    {
+        rc = cfg_set_instance_fmt(CFG_VAL(INTEGER, 1),
+                                  "/agent:%s/module:%s/unload_holders:",
+                                  ta, module);
+        if (rc != 0)
+        {
+            ERROR("Failed to set unload holders for the module '%s' on %s: %r",
+                  module, ta, rc);
+            return rc;
+        }
+
         rc = tapi_cfg_module_unload(ta, module);
+    }
 
     if (rc != 0)
         return rc;

--- a/net-drv-ts/lib/net_drv_ts.h
+++ b/net-drv-ts/lib/net_drv_ts.h
@@ -144,6 +144,28 @@ extern size_t net_drv_sendto_recv_check(rcf_rpc_server *rpcs_sender,
                                         const char *vpref);
 
 /**
+ * Same as net_drv_sendto_recv_check() but do not fail if receiver
+ * does not become readable and return 0.
+ *
+ * @param rpcs_sender       RPC server from which to send.
+ * @param s_sender          Socket from which to send.
+ * @param dst_addr          If not @c NULL, @b sendto() should
+ *                          be called with this destination.
+ * @param rpcs_receiver     RPC server on which to receive.
+ * @param s_receiver        Socket on which to receive.
+ * @param vpref             Prefix for verdicts.
+ *
+ * @return Number of bytes sent and received.
+ */
+extern size_t net_drv_sendto_recv_check_may_loss(
+                    rcf_rpc_server *rpcs_sender,
+                    int s_sender,
+                    const struct sockaddr *dst_addr,
+                    rcf_rpc_server *rpcs_receiver,
+                    int s_receiver,
+                    const char *vpref);
+
+/**
  * Send data in both directions between a pair of connected
  * sockets, check that it can be received.
  * In case of any failure, print verdict and stop the test.

--- a/net-drv-ts/offload/receive_offload.c
+++ b/net-drv-ts/offload/receive_offload.c
@@ -348,8 +348,17 @@ main(int argc, char *argv[])
     {
         if (stats.first_big > 0)
         {
-            TEST_VERDICT("A large packet was captured while both "
-                         "LRO and GRO are disabled");
+            if (lro_on && !rx_csum_on)
+            {
+                RING_VERDICT("Some packets are coalesced when LRO "
+                             "is enabled even if Rx checksumming is "
+                             "turned off");
+            }
+            else
+            {
+                TEST_VERDICT("A large packet was captured while both "
+                             "LRO and GRO are disabled");
+            }
         }
     }
     else

--- a/net-drv-ts/prologue.c
+++ b/net-drv-ts/prologue.c
@@ -47,7 +47,7 @@ load_required_modules(const char *ta, void *cookie)
 
         if (strcmp_start("sfc", driver) == 0)
         {
-            rc = tapi_cfg_module_add_from_ta_dir(ta, "sfc", TRUE);
+            rc = tapi_cfg_module_add_from_ta_dir_or_fallback(ta, "sfc", TRUE);
         }
         else if (strcmp("xilinx_efct", driver) == 0)
         {

--- a/net-drv-ts/ptp/adj_frequency.c
+++ b/net-drv-ts/ptp/adj_frequency.c
@@ -125,7 +125,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b clock_adjtime() to check whether current frequency "
               "offset is zero.");

--- a/net-drv-ts/ptp/adj_setoffset.c
+++ b/net-drv-ts/ptp/adj_setoffset.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Use @b clock_adjtime() to add @p time_offset seconds "
               "to the current time on the PTP device. With help of "

--- a/net-drv-ts/ptp/clock_caps.c
+++ b/net-drv-ts/ptp/clock_caps.c
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b ioctl(@c PTP_CLOCK_GETCAPS) on the PTP device FD.");
     RPC_AWAIT_ERROR(iut_rpcs);

--- a/net-drv-ts/ptp/get_time.c
+++ b/net-drv-ts/ptp/get_time.c
@@ -54,7 +54,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b clock_gettime() with PTP device FD to get the "
               "first timestamp.");

--- a/net-drv-ts/ptp/ptp4l.c
+++ b/net-drv-ts/ptp/ptp4l.c
@@ -166,11 +166,11 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd_iut);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd_iut, "IUT");
 
     TEST_STEP("Find out PTP device associated with the Tester interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(tst_rpcs, tst_if->if_name, &fd_tst);
+    net_drv_open_ptp_fd(tst_rpcs, tst_if->if_name, &fd_tst, "Tester");
 
     TEST_STEP("Check that @b ptp4l is available on IUT and Tester.");
     find_ptp4l(iut_rpcs, "IUT");

--- a/net-drv-ts/ptp/set_time.c
+++ b/net-drv-ts/ptp/set_time.c
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     if (ts < 0)
     {

--- a/net-drv-ts/ptp/sfptpd.c
+++ b/net-drv-ts/ptp/sfptpd.c
@@ -281,7 +281,7 @@ main(int argc, char *argv[])
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "check that it can be opened to be sure that PTP is "
               "supported.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
     RPC_CLOSE(iut_rpcs, fd);
 
     CHECK_RC(tapi_job_factory_rpc_create(iut_rpcs, &factory));

--- a/net-drv-ts/ptp/sys_offset.c
+++ b/net-drv-ts/ptp/sys_offset.c
@@ -53,7 +53,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b ioctl(@c PTP_SYS_OFFSET) on the PTP device FD "
               "asking for @p n_samples samples.");

--- a/net-drv-ts/ptp/sys_offset_extended.c
+++ b/net-drv-ts/ptp/sys_offset_extended.c
@@ -50,7 +50,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b ioctl(@c PTP_SYS_OFFSET_EXTENDED) on the PTP device "
               "FD asking for @p n_samples samples.");

--- a/net-drv-ts/ptp/sys_offset_precise.c
+++ b/net-drv-ts/ptp/sys_offset_precise.c
@@ -42,7 +42,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Find out PTP device associated with the IUT interface, "
               "call @b open() to get its FD.");
-    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd);
+    net_drv_open_ptp_fd(iut_rpcs, iut_if->if_name, &fd, "");
 
     TEST_STEP("Call @b ioctl(@c PTP_SYS_OFFSET_PRECISE) on the PTP device "
               "FD to get timestamps for PTP device, @c CLOCK_REALTIME "

--- a/net-drv-ts/rss/common_rss.h
+++ b/net-drv-ts/rss/common_rss.h
@@ -13,6 +13,7 @@
 #include "net_drv_test.h"
 #include "tapi_cfg_if_rss.h"
 #include "tapi_bpf.h"
+#include "te_toeplitz.h"
 
 /**
  * Send a few packets and check whether expected Rx queue received them.
@@ -122,5 +123,83 @@ net_drv_rss_get_check_hkey(const char *ta, const char *if_name,
 
     RING("RSS hash key: %Tm", *key, *len);
 }
+
+/** Helper structure for RSS tests */
+typedef struct net_drv_rss_ctx {
+    const char *ta; /**< Test Agent name */
+    const char *if_name; /**< Interface name */
+    unsigned int rss_ctx; /**< RSS context id */
+    unsigned int indir_table_size; /**< Size of indirection table */
+    unsigned int rx_queues; /**< Number of Rx queues */
+    uint8_t *hash_key; /**< Hash key */
+    size_t key_len; /**< Length of hash key */
+    te_toeplitz_hash_cache *cache; /**< Cache used for computing Toeplitz
+                                        hash */
+    te_toeplitz_hash_variant hash_variant; /**< Variant of Toeplitz
+                                                algorithm to use */
+} net_drv_rss_ctx;
+
+/** Initializer for net_drv_rss_ctx */
+#define NET_DRV_RSS_CTX_INIT \
+    {                                                                     \
+        .ta = "", .if_name = "", .rss_ctx = 0, .indir_table_size = 0,     \
+        .rx_queues = 0, .hash_key = NULL, .key_len = 0, .cache = NULL,    \
+        .hash_variant = TE_TOEPLITZ_HASH_STANDARD                         \
+    }
+
+/**
+ * Fill fields of RSS test context.
+ *
+ * @note This function can print verdict and jump to cleanup.
+ *
+ * @param ctx       Context structure to initialize
+ * @param ta        Test agent name
+ * @param if_name   Interface name
+ * @param rss_ctx   RSS context id
+ */
+extern void net_drv_rss_ctx_prepare(net_drv_rss_ctx *ctx,
+                                    const char *ta,
+                                    const char *if_name,
+                                    unsigned int rss_ctx);
+
+/**
+ * Release resources allocated for RSS test context.
+ *
+ * @param ctx     Pointer to context structure
+ */
+extern void net_drv_rss_ctx_release(net_drv_rss_ctx *ctx);
+
+/**
+ * Change hash key used for Toeplitz hash computation.
+ *
+ * @param ctx       Pointer to context structure
+ * @param hash_key  New hash key
+ * @param key_len   Key length
+ *
+ * @return Status code.
+ */
+extern te_errno net_drv_rss_ctx_change_key(net_drv_rss_ctx *ctx,
+                                           uint8_t *hash_key,
+                                           unsigned int key_len);
+
+/**
+ * Predict Toeplitz hash value, indirection table index and
+ * Rx queue id for given pairs of addresses/ports.
+ *
+ * @param ctx         RSS test context
+ * @param src_addr    Source address/port
+ * @param dst_addr    Destination address/port
+ * @param hash_out    Where to save hash value (may be @c NULL)
+ * @param idx_out     Where to save indirection table index (may be @c NULL)
+ * @param queue_out   Where to save Rx queue id (may be @c NULL)
+ *
+ * @return Status code.
+ */
+extern te_errno net_drv_rss_predict(net_drv_rss_ctx *ctx,
+                                    const struct sockaddr *src_addr,
+                                    const struct sockaddr *dst_addr,
+                                    unsigned int *hash_out,
+                                    unsigned int *idx_out,
+                                    unsigned int *queue_out);
 
 #endif /* !__TS_NET_DRV_COMMON_RSS_H__ */

--- a/net-drv-ts/rss/hash_key_set.c
+++ b/net-drv-ts/rss/hash_key_set.c
@@ -46,34 +46,22 @@ main(int argc, char *argv[])
     const struct sockaddr *tst_addr = NULL;
     rpc_socket_type sock_type;
 
-    void *iut_netaddr = NULL;
-    void *tst_netaddr = NULL;
-    uint16_t iut_port;
-    uint16_t tst_port;
-    size_t addr_size;
-
     int iut_s = -1;
     int tst_s = -1;
 
-    uint8_t *hash_key = NULL;
-    size_t key_len;
-    te_toeplitz_hash_cache *cache = NULL;
     unsigned int hash;
     uint8_t *new_key = NULL;
 
-    int rx_queues;
-    unsigned int table_size;
     unsigned int idx;
     unsigned int i;
     unsigned int j;
-    int first_entry = -1;
-    int entry;
-    te_bool fix_indir_table = TRUE;
     unsigned int bpf_id = 0;
 
-    int init_queue;
-    int new_queue;
+    unsigned int init_queue;
+    unsigned int new_queue;
     te_bool test_failed = FALSE;
+
+    net_drv_rss_ctx ctx = NET_DRV_RSS_CTX_INIT;
 
     TEST_START;
     TEST_GET_PCO(iut_rpcs);
@@ -83,86 +71,15 @@ main(int argc, char *argv[])
     TEST_GET_ADDR(tst_rpcs, tst_addr);
     TEST_GET_SOCK_TYPE(sock_type);
 
-    addr_size = te_netaddr_get_size(iut_addr->sa_family);
+    net_drv_rss_ctx_prepare(&ctx, iut_rpcs->ta, iut_if->if_name, 0);
 
-    TEST_STEP("Check that RSS hash key can be obtained for IUT "
-              "interface.");
-
-    net_drv_rss_get_check_hkey(iut_rpcs->ta, iut_if->if_name, 0,
-                               &hash_key, &key_len);
-
-    new_key = tapi_calloc(key_len, 1);
-
-    TEST_STEP("Check that multiple Rx queues are available.");
-
-    CHECK_RC(tapi_cfg_if_rss_rx_queues_get(
-                    iut_rpcs->ta, iut_if->if_name, &rx_queues));
-    if (rx_queues <= 1)
-        TEST_SKIP("Multiple Rx queues should be available");
-
-    TEST_STEP("Check that multiple entries are present in RSS hash "
-              "indirection table.");
-
-    CHECK_RC(tapi_cfg_if_rss_indir_table_size(iut_rpcs->ta,
-                                              iut_if->if_name, 0,
-                                              &table_size));
-    if (table_size <= 1)
-    {
-        TEST_SKIP("RSS indirection table should have multiple "
-                  "entries");
-    }
-
-    TEST_STEP("Make sure that Toeplitz hash function is used on "
-              "the IUT interface.");
-    NET_DRV_RSS_CHECK_SET_HFUNC(
-          iut_rpcs->ta, iut_if->if_name, 0,
-          "toeplitz", TEST_SKIP("Test cannot be run without enabling "
-                                "Toeplitz hash function"));
-
-    TEST_STEP("Make sure that RSS hash indirection table mentions more "
-              "than one Rx queue.");
-
-    CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
-                                       iut_if->if_name, 0, 0,
-                                       &first_entry));
-    for (i = 1; i < table_size; i++)
-    {
-        CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
-                                           iut_if->if_name, 0, i,
-                                           &entry));
-
-        if (first_entry != entry)
-        {
-            fix_indir_table = FALSE;
-            break;
-        }
-    }
-
-    if (fix_indir_table)
-    {
-        CHECK_RC(tapi_cfg_if_rss_fill_indir_table(iut_rpcs->ta,
-                                                  iut_if->if_name, 0,
-                                                  0, rx_queues - 1));
-    }
+    new_key = tapi_calloc(ctx.key_len, 1);
 
     CHECK_RC(tapi_cfg_if_rss_print_indir_table(iut_rpcs->ta,
                                                iut_if->if_name, 0));
 
-    CHECK_NOT_NULL(cache = te_toeplitz_cache_init_size(hash_key, key_len));
-
-    CHECK_NOT_NULL(iut_netaddr = te_sockaddr_get_netaddr(iut_addr));
-    CHECK_NOT_NULL(tst_netaddr = te_sockaddr_get_netaddr(tst_addr));
-    iut_port = te_sockaddr_get_port(iut_addr);
-    tst_port = te_sockaddr_get_port(tst_addr);
-
-    hash = te_toeplitz_hash(
-                cache, addr_size, tst_netaddr, tst_port,
-                iut_netaddr, iut_port);
-    idx = hash % table_size;
-
-    CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
-                                       iut_if->if_name, 0, idx,
-                                       &init_queue));
+    CHECK_RC(net_drv_rss_predict(&ctx, tst_addr, iut_addr,
+                                 &hash, &idx, &init_queue));
 
     TEST_STEP("Create a pair of connected sockets of type @p sock_type "
               "on IUT and Tester.");
@@ -175,7 +92,7 @@ main(int argc, char *argv[])
               "Rx queue determined by the current hash key value.");
 
     RING("With current hash key hash value should be 0x%x and packets "
-         "should go via queue %d specified in indirection table entry %u",
+         "should go via queue %u specified in indirection table entry %u",
          hash, init_queue, idx);
 
     CHECK_RC(tapi_bpf_rxq_stats_get_id(iut_rpcs->ta, iut_if->if_name,
@@ -196,22 +113,13 @@ main(int argc, char *argv[])
 
     for (i = 0; i < MAX_ATTEMPTS; i++)
     {
-        for (j = 0; j < key_len; j++)
+        for (j = 0; j < ctx.key_len; j++)
             new_key[j] = rand_range(0, 0xff);
 
-        te_toeplitz_hash_fini(cache);
-        CHECK_NOT_NULL(cache = te_toeplitz_cache_init_size(new_key,
-                                                           key_len));
+        CHECK_RC(net_drv_rss_ctx_change_key(&ctx, new_key, ctx.key_len));
 
-        hash = te_toeplitz_hash(
-                    cache, addr_size, tst_netaddr, tst_port,
-                    iut_netaddr, iut_port);
-        idx = hash % table_size;
-
-        CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
-                                           iut_if->if_name, 0, idx,
-                                           &new_queue));
-
+        CHECK_RC(net_drv_rss_predict(&ctx, tst_addr, iut_addr,
+                                     &hash, &idx, &new_queue));
         if (new_queue != init_queue)
             break;
     }
@@ -226,7 +134,7 @@ main(int argc, char *argv[])
 
     CHECK_RC(tapi_cfg_if_rss_hash_key_set_local(iut_rpcs->ta,
                                                 iut_if->if_name, 0,
-                                                new_key, key_len));
+                                                new_key, ctx.key_len));
     CHECK_RC(tapi_cfg_if_rss_hash_indir_commit(iut_rpcs->ta,
                                                iut_if->if_name, 0));
 
@@ -235,7 +143,7 @@ main(int argc, char *argv[])
               "processed by the new Rx queue.");
 
     RING("With changed hash key hash value should be 0x%x and packets "
-         "should go via queue %d specified in indirection table entry %u",
+         "should go via queue %u specified in indirection table entry %u",
          hash, new_queue, idx);
 
     CHECK_RC(net_drv_rss_send_check_stats(tst_rpcs, tst_s, iut_rpcs, iut_s,
@@ -253,9 +161,9 @@ cleanup:
 
     CLEANUP_CHECK_RC(tapi_bpf_rxq_stats_reset(iut_rpcs->ta, bpf_id));
 
-    te_toeplitz_hash_fini(cache);
-    free(hash_key);
     free(new_key);
+
+    net_drv_rss_ctx_release(&ctx);
 
     TEST_END;
 }

--- a/net-drv-ts/rss/prologue.c
+++ b/net-drv-ts/rss/prologue.c
@@ -13,22 +13,261 @@
 #define TE_TEST_NAME    "rss/prologue"
 
 #include "net_drv_test.h"
+#include "te_toeplitz.h"
 #include "tapi_bpf.h"
 #include "tapi_cfg_if_rss.h"
 #include "tapi_bpf_rxq_stats.h"
+#include "common_rss.h"
+
+/* Send some packets and find out which Rx queue received them. */
+static void
+send_get_rx_queue(rcf_rpc_server *sender_rpcs, int sender_s,
+                  rcf_rpc_server *receiver_rpcs, int receiver_s,
+                  unsigned int bpf_id, unsigned int *queue)
+{
+    unsigned int i;
+    static unsigned int pkts_num = 10;
+
+    tapi_bpf_rxq_stats *stats = NULL;
+    unsigned int stats_count;
+    long int got_queue = -1;
+    unsigned int reg_pkts = 0;
+
+    CHECK_RC(tapi_bpf_rxq_stats_clear(receiver_rpcs->ta, bpf_id));
+
+    for (i = 0; i < pkts_num; i++)
+    {
+        net_drv_send_recv_check(sender_rpcs, sender_s,
+                                receiver_rpcs, receiver_s, "");
+    }
+
+    CHECK_RC(tapi_bpf_rxq_stats_read(receiver_rpcs->ta, bpf_id, &stats,
+                                     &stats_count));
+
+    tapi_bpf_rxq_stats_print(NULL, stats, stats_count);
+
+    for (i = 0; i < stats_count; i++)
+    {
+        if (stats[i].pkts > 0)
+        {
+            if (got_queue >= 0)
+                TEST_VERDICT("Packets were received over more than one queue");
+            else
+                got_queue = stats[i].rx_queue;
+
+            reg_pkts += stats[i].pkts;
+        }
+    }
+
+    if (reg_pkts == 0)
+    {
+        TEST_VERDICT("No packets was registered for any Rx queue");
+    }
+    else if (reg_pkts != pkts_num)
+    {
+        ERROR("%u packets were registered instead of %u",
+              reg_pkts, pkts_num);
+        TEST_VERDICT("Unexpected number of packets was registered");
+    }
+
+    *queue = got_queue;
+}
+
+/*
+ * Make sure that indirection table mentions more than one Rx queue,
+ * so that different RSS hash values can lead to selection of
+ * different Rx queues.
+ */
+static void
+check_fix_indir_table(const char *ta, const char *if_name,
+                      unsigned int rx_queues, unsigned int table_size)
+{
+    int first_entry = -1;
+    int entry;
+    te_bool fix_indir_table = TRUE;
+    unsigned int i;
+
+    CHECK_RC(tapi_cfg_if_rss_indir_get(ta, if_name, 0, 0,
+                                       &first_entry));
+    for (i = 1; i < table_size; i++)
+    {
+        CHECK_RC(tapi_cfg_if_rss_indir_get(ta, if_name, 0, i,
+                                           &entry));
+
+        if (first_entry != entry)
+        {
+            fix_indir_table = FALSE;
+            break;
+        }
+    }
+
+    if (fix_indir_table)
+    {
+        CHECK_RC(tapi_cfg_if_rss_fill_indir_table(ta, if_name, 0,
+                                                  0, rx_queues - 1));
+    }
+
+    CHECK_RC(tapi_cfg_if_rss_print_indir_table(ta, if_name, 0));
+}
+
+/*
+ * Determine whether standard Toeplitz hash is used or "symmetric
+ * Toeplitz".
+ */
+static void
+detect_toeplitz_variant(rcf_rpc_server *iut_rpcs, rcf_rpc_server *tst_rpcs,
+                        const struct sockaddr *iut_addr,
+                        const struct sockaddr *tst_addr,
+                        const char *iut_if_name, int *iut_s, int *tst_s,
+                        unsigned int bpf_id, unsigned int table_size,
+                        te_toeplitz_hash_cache *cache)
+{
+    struct sockaddr_storage new_iut_addr_st;
+    struct sockaddr_storage new_tst_addr_st;
+    struct sockaddr *new_iut_addr = NULL;
+    struct sockaddr *new_tst_addr = NULL;
+    uint16_t iut_port = 0;
+    uint16_t tst_port = 0;
+    static const unsigned int max_attempts = 10000;
+    static const unsigned int min_port = 20000;
+
+    unsigned int hash_std;
+    unsigned int hash_sym;
+    unsigned int idx_std;
+    unsigned int idx_sym;
+    int queue_std;
+    int queue_sym;
+    unsigned int queue_got;
+    unsigned int i;
+    int toeplitz_variant = TE_TOEPLITZ_HASH_STANDARD;
+
+    cfg_obj_descr obj_descr;
+
+    tapi_sockaddr_clone_exact(iut_addr, &new_iut_addr_st);
+    tapi_sockaddr_clone_exact(tst_addr, &new_tst_addr_st);
+    new_iut_addr = SA(&new_iut_addr_st);
+    new_tst_addr = SA(&new_tst_addr_st);
+
+    for (i = 0; i < max_attempts; i++)
+    {
+        CHECK_RC(te_toeplitz_hash_sa(cache, new_tst_addr, new_iut_addr,
+                                     TE_TOEPLITZ_HASH_STANDARD, &hash_std));
+        CHECK_RC(te_toeplitz_hash_sa(cache, new_tst_addr, new_iut_addr,
+                                     TE_TOEPLITZ_HASH_SYM_OR_XOR,
+                                     &hash_sym));
+        idx_std = hash_std % table_size;
+        idx_sym = hash_sym % table_size;
+
+        if (idx_std != idx_sym)
+        {
+            CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
+                                               iut_if_name, 0, idx_std,
+                                               &queue_std));
+
+            CHECK_RC(tapi_cfg_if_rss_indir_get(iut_rpcs->ta,
+                                               iut_if_name, 0, idx_sym,
+                                               &queue_sym));
+
+            if (queue_std != queue_sym)
+            {
+                if (iut_port == 0 ||
+                    (rpc_check_port_is_free(iut_rpcs, iut_port) &&
+                     rpc_check_port_is_free(tst_rpcs, tst_port)))
+                    break;
+            }
+        }
+
+        iut_port = rand_range(min_port, 0xffff);
+        tst_port = rand_range(min_port, 0xffff);
+        te_sockaddr_set_port(new_iut_addr, htons(iut_port));
+        te_sockaddr_set_port(new_tst_addr, htons(tst_port));
+    }
+
+    GEN_CONNECTION(iut_rpcs, tst_rpcs, RPC_SOCK_DGRAM, RPC_PROTO_DEF,
+                   new_iut_addr, new_tst_addr, iut_s, tst_s);
+
+    CHECK_RC(tapi_bpf_rxq_stats_reset(iut_rpcs->ta, bpf_id));
+    CHECK_RC(
+        tapi_bpf_rxq_stats_set_params(
+             iut_rpcs->ta, bpf_id, iut_addr->sa_family,
+             new_tst_addr, new_iut_addr,
+             IPPROTO_UDP, TRUE));
+
+    RING("Standard Toeplitz hash should be equal to %u, mapping into "
+         "indirection table entry %u, where queue %d is specified",
+         hash_std, idx_std, queue_std);
+    RING("Symmetric Toeplitz hash should be equal to %u, mapping "
+         "into indirection table entry %u, where queue %d is specified",
+         hash_sym, idx_sym, queue_sym);
+
+    send_get_rx_queue(tst_rpcs, *tst_s, iut_rpcs, *iut_s,
+                      bpf_id, &queue_got);
+
+    if ((int)queue_got == queue_std)
+    {
+        RING("NIC uses standard Toeplitz hash");
+    }
+    else if ((int)queue_got == queue_sym)
+    {
+        RING_VERDICT("NIC uses symmetric-or-xor Toeplitz hash");
+        toeplitz_variant = TE_TOEPLITZ_HASH_SYM_OR_XOR;
+    }
+    else
+    {
+        TEST_VERDICT("Cannot detect Toeplitz hash variant");
+    }
+
+    /*
+     * Save information about detected Toeplitz hash variant in
+     * configuration tree where other tests can read it.
+     */
+
+    memset(&obj_descr, 0, sizeof(obj_descr));
+    obj_descr.type = CVT_INT32;
+    obj_descr.access = CFG_READ_CREATE;
+    obj_descr.def_val = NULL;
+
+    CHECK_RC(cfg_register_object_str("/local/iut_toeplitz_variant",
+                                     &obj_descr, NULL));
+    CHECK_RC(cfg_add_instance_fmt(NULL, CFG_VAL(INT32, toeplitz_variant),
+                                  "/local:/iut_toeplitz_variant:"));
+
+    RPC_CLOSE(iut_rpcs, *iut_s);
+    RPC_CLOSE(tst_rpcs, *tst_s);
+}
 
 int
 main(int argc, char **argv)
 {
     rcf_rpc_server *iut_rpcs = NULL;
+    rcf_rpc_server *tst_rpcs = NULL;
     const struct if_nameindex *iut_if = NULL;
+    const struct sockaddr *iut_addr = NULL;
+    const struct sockaddr *tst_addr = NULL;
+
+    int iut_s = -1;
+    int tst_s = -1;
+
+    uint8_t *hash_key = NULL;
+    size_t key_len;
+    te_toeplitz_hash_cache *cache = NULL;
 
     unsigned int bpf_id;
     int rx_queues;
+    unsigned int table_size;
 
     TEST_START;
     TEST_GET_PCO(iut_rpcs);
+    TEST_GET_PCO(tst_rpcs);
     TEST_GET_IF(iut_if);
+    TEST_GET_ADDR(iut_rpcs, iut_addr);
+    TEST_GET_ADDR(tst_rpcs, tst_addr);
+
+    /*
+     * There should be more than one Rx queue and more than one
+     * indirection table entry to see whether RSS hash indirection
+     * works.
+     */
 
     rc = tapi_cfg_if_rss_rx_queues_get(iut_rpcs->ta, iut_if->if_name,
                                        &rx_queues);
@@ -39,17 +278,47 @@ main(int argc, char **argv)
         else
             TEST_STOP;
     }
+    if (rx_queues <= 1)
+        TEST_SKIP("There is no multiple Rx queues");
+
+    CHECK_RC(tapi_cfg_if_rss_indir_table_size(iut_rpcs->ta,
+                                              iut_if->if_name, 0,
+                                              &table_size));
+    if (table_size <= 1)
+        TEST_SKIP("There is no multiple indirection table entries");
+
+    /* Only Toeplitz hash is supported in the tests currently */
+    NET_DRV_RSS_CHECK_SET_HFUNC(iut_rpcs->ta, iut_if->if_name, 0,
+                                "toeplitz", TEST_STOP);
+
+    /* Indirection table should mention more than one Rx queue */
+    check_fix_indir_table(iut_rpcs->ta, iut_if->if_name,
+                          rx_queues, table_size);
+
+    net_drv_rss_get_check_hkey(iut_rpcs->ta, iut_if->if_name, 0,
+                               &hash_key, &key_len);
+    CHECK_NOT_NULL(cache = te_toeplitz_cache_init_size(hash_key,
+                                                       key_len));
 
     /* Link XDP hook used to get per-queue statistics */
-
     CHECK_RC(tapi_bpf_rxq_stats_init(iut_rpcs->ta, iut_if->if_name,
                                      "rss_bpf", &bpf_id));
+
+    /* Detect whether nonstandard Toeplitz hash variant is used */
+    detect_toeplitz_variant(iut_rpcs, tst_rpcs, iut_addr, tst_addr,
+                            iut_if->if_name, &iut_s, &tst_s, bpf_id,
+                            table_size, cache);
 
     CHECK_RC(cfg_synchronize("/:", TRUE));
 
     TEST_SUCCESS;
 
 cleanup:
+
+    CLEANUP_RPC_CLOSE(iut_rpcs, iut_s);
+    CLEANUP_RPC_CLOSE(tst_rpcs, tst_s);
+
+    te_toeplitz_hash_fini(cache);
 
     TEST_END;
 }

--- a/net-drv-ts/rss/prologue.c
+++ b/net-drv-ts/rss/prologue.c
@@ -304,6 +304,13 @@ main(int argc, char **argv)
     CHECK_RC(tapi_bpf_rxq_stats_init(iut_rpcs->ta, iut_if->if_name,
                                      "rss_bpf", &bpf_id));
 
+    /*
+     * On balin-x710 configuration (Intel X710 NIC) IUT may not receive UDP
+     * packet sent from Tester in the next step without this delay.
+     */
+    te_motivated_sleep(2, "waiting after linking XDP hook helps to "
+                       "avoid problems with receiving packets");
+
     /* Detect whether nonstandard Toeplitz hash variant is used */
     detect_toeplitz_variant(iut_rpcs, tst_rpcs, iut_addr, tst_addr,
                             iut_if->if_name, &iut_s, &tst_s, bpf_id,

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -122,6 +122,11 @@ GEN_OPTS+=(--trc-no-expected)
 GEN_OPTS+=(--trc-no-total --trc-no-unspec)
 GEN_OPTS+=(--tester-only-req-logues)
 
+if [[ -z "${TE_ENV_SFPTPD}" ]] ; then
+    # Path to sfptpd is not exported
+    RUN_OPTS+=("--tester-req=!SFPTPD")
+fi
+
 "${TE_BASE}"/dispatcher.sh "${GEN_OPTS[@]}" "${RUN_OPTS[@]}"
 RESULT=$?
 

--- a/scripts/trc-status.sh
+++ b/scripts/trc-status.sh
@@ -11,7 +11,9 @@ source "$(dirname "$(which $0)")"/guess.sh
 
 declare -a COMMON_OPTS
 COMMON_OPTS+=(--db="${TE_TS_TRC_DB}")
-COMMON_OPTS+=(--key2html="${SF_TS_CONFDIR}"/trc.key2html)
+if [[ -n "${TS_RIGSDIR}" ]] && [[ -r "${TS_RIGSDIR}"/trc.key2html ]] ; then
+    COMMON_OPTS+=(--key2html="${TS_RIGSDIR}"/trc.key2html)
+fi
 
 declare -a COMMON_TAGS
 

--- a/scripts/trc-status.sh
+++ b/scripts/trc-status.sh
@@ -199,7 +199,7 @@ declare -a I40E_STATUS_OPTS
 I40E_STATUS_OPTS+=("${COMMON_OPTS[@]}")
 I40E_STATUS_OPTS+=(--1-name="Reference")
 I40E_STATUS_OPTS+=("${REF_OPTS[@]}")
-I40E_STATUS_OPTS+=(--2-name="X2 sfc")
+I40E_STATUS_OPTS+=(--2-name="Intel i40e")
 I40E_STATUS_OPTS+=(--2-show-keys)
 I40E_STATUS_OPTS+=("${I40E_OPTS2[@]}")
 
@@ -229,7 +229,7 @@ declare -a ICE_STATUS_OPTS
 ICE_STATUS_OPTS+=("${COMMON_OPTS[@]}")
 ICE_STATUS_OPTS+=(--1-name="Reference")
 ICE_STATUS_OPTS+=("${REF_OPTS[@]}")
-ICE_STATUS_OPTS+=(--2-name="X2 sfc")
+ICE_STATUS_OPTS+=(--2-name="Intel ice")
 ICE_STATUS_OPTS+=(--2-show-keys)
 ICE_STATUS_OPTS+=("${ICE_OPTS2[@]}")
 
@@ -259,7 +259,7 @@ declare -a MLX5_STATUS_OPTS
 MLX5_STATUS_OPTS+=("${COMMON_OPTS[@]}")
 MLX5_STATUS_OPTS+=(--1-name="Reference")
 MLX5_STATUS_OPTS+=("${REF_OPTS[@]}")
-MLX5_STATUS_OPTS+=(--2-name="X2 sfc")
+MLX5_STATUS_OPTS+=(--2-name="Nvidia mlx5")
 MLX5_STATUS_OPTS+=(--2-show-keys)
 MLX5_STATUS_OPTS+=("${MLX5_OPTS2[@]}")
 

--- a/scripts/trc-status.sh
+++ b/scripts/trc-status.sh
@@ -176,3 +176,94 @@ te-trc-diff \
     --html=SN1022-Virtio-Net.html \
     --title="SN1022 Virtio-Net status" \
     "${SN1022_VNET_STATUS_OPTS[@]}"
+
+
+#
+# Intel i40e driver status
+#
+
+declare -a I40E_TAGS
+I40E_TAGS+=(i40e)
+I40E_TAGS+=(pci-8086-1572)
+
+declare -a I40E_OPTS2
+
+for tag in "${COMMON_TAGS[@]}" ; do
+    I40E_OPTS2+=(-2 "${tag}")
+done
+for tag in "${I40E_TAGS[@]}" ; do
+    I40E_OPTS2+=(-2 "${tag}")
+done
+
+declare -a I40E_STATUS_OPTS
+I40E_STATUS_OPTS+=("${COMMON_OPTS[@]}")
+I40E_STATUS_OPTS+=(--1-name="Reference")
+I40E_STATUS_OPTS+=("${REF_OPTS[@]}")
+I40E_STATUS_OPTS+=(--2-name="X2 sfc")
+I40E_STATUS_OPTS+=(--2-show-keys)
+I40E_STATUS_OPTS+=("${I40E_OPTS2[@]}")
+
+te-trc-diff \
+    --html=Intel-i40e.html \
+    --title="Intel i40e driver status" \
+    "${I40E_STATUS_OPTS[@]}"
+
+
+#
+# Intel ice driver status
+#
+
+declare -a ICE_TAGS
+ICE_TAGS+=(ice)
+
+declare -a ICE_OPTS2
+
+for tag in "${COMMON_TAGS[@]}" ; do
+    ICE_OPTS2+=(-2 "${tag}")
+done
+for tag in "${ICE_TAGS[@]}" ; do
+    ICE_OPTS2+=(-2 "${tag}")
+done
+
+declare -a ICE_STATUS_OPTS
+ICE_STATUS_OPTS+=("${COMMON_OPTS[@]}")
+ICE_STATUS_OPTS+=(--1-name="Reference")
+ICE_STATUS_OPTS+=("${REF_OPTS[@]}")
+ICE_STATUS_OPTS+=(--2-name="X2 sfc")
+ICE_STATUS_OPTS+=(--2-show-keys)
+ICE_STATUS_OPTS+=("${ICE_OPTS2[@]}")
+
+te-trc-diff \
+    --html=Intel-ice.html \
+    --title="Intel ice driver status" \
+    "${ICE_STATUS_OPTS[@]}"
+
+
+#
+# Nvidia mlx5 driver status
+#
+
+declare -a MLX5_TAGS
+MLX5_TAGS+=(mlx5_core)
+
+declare -a MLX5_OPTS2
+
+for tag in "${COMMON_TAGS[@]}" ; do
+    MLX5_OPTS2+=(-2 "${tag}")
+done
+for tag in "${MLX5_TAGS[@]}" ; do
+    MLX5_OPTS2+=(-2 "${tag}")
+done
+
+declare -a MLX5_STATUS_OPTS
+MLX5_STATUS_OPTS+=("${COMMON_OPTS[@]}")
+MLX5_STATUS_OPTS+=(--1-name="Reference")
+MLX5_STATUS_OPTS+=("${REF_OPTS[@]}")
+MLX5_STATUS_OPTS+=(--2-name="X2 sfc")
+MLX5_STATUS_OPTS+=(--2-show-keys)
+MLX5_STATUS_OPTS+=("${MLX5_OPTS2[@]}")
+
+te-trc-diff \
+    --html=Nvidia-mlx5.html \
+    --title="Nvidia mlx5 driver status" \
+    "${MLX5_STATUS_OPTS[@]}"

--- a/scripts/trc.sh
+++ b/scripts/trc.sh
@@ -4,5 +4,10 @@
 
 source "$(dirname "$(which "$0")")"/guess.sh
 
-. $TE_BASE/scripts/trc.sh --db="${TE_TS_TOPDIR}/trc/top.xml" \
-      --key2html="${TE_TS_TOPDIR}/trc/trc.key2html" "$@"
+declare -a OPTS
+OPTS+=(--db="${TE_TS_TRC_DB}")
+if [[ -n "${TS_RIGSDIR}" ]] && [[ -r "${TS_RIGSDIR}"/trc.key2html ]] ; then
+    OPTS+=(--key2html="${TS_RIGSDIR}"/trc.key2html)
+fi
+
+. $TE_BASE/scripts/trc.sh "${OPTS[@]}" $@"

--- a/scripts/trc_update
+++ b/scripts/trc_update
@@ -6,4 +6,4 @@ source "$(dirname "$(which "$0")")"/guess.sh
 
 . $TE_BASE/scripts/guess.sh
 te_trc_update_wrapper --def-conf-tester=tester.conf \
-    --def-db=trc/top.xml "$@"
+    --def-db=${MYDIR}/../trc/top.xml "$@"

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -304,6 +304,11 @@
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
+        <results tags="i40e" key="WONTFIX SYSFS-DEBUG" notes="intel/i40e does not provide debug in sysfs">
+          <result value="FAILED">
+            <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX SYSFS-DEBUG" notes="ice does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -29,7 +29,7 @@
         </results>
         <results tags="mlx5_core&amp;linux-mm&gt;510" key="WONTFIX MOD-VERSION">
           <result value="PASSED">
-            <verdict>Module igb has no version information</verdict>
+            <verdict>Module mlx5_core has no version information</verdict>
           </result>
         </results>
         <results tags="virtio-pci" key="WONTFIX VIRTIO-NET-VERSION" notes="VirtIO net module has no version information">

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -600,14 +600,79 @@
         </results>
       </iter>
       <iter result="PASSED">
-        <arg name="env"/>
+        <arg name="env">VAR.env.peer2peer</arg>
         <arg name="mtu">9000</arg>
         <arg name="tx"/>
         <arg name="gso_on"/>
-        <arg name="tso_on"/>
+        <arg name="tso_on">FALSE</arg>
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="NET-44" notes="X3 NIC: MTU can be configured to be between 576 and 1960 bytes">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env">VAR.env.peer2peer_ipv6</arg>
+        <arg name="mtu">9000</arg>
+        <arg name="tx"/>
+        <arg name="gso_on"/>
+        <arg name="tso_on">FALSE</arg>
+        <arg name="pkt_size"/>
+        <arg name="sends_num"/>
+        <notes/>
+        <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="NET-44" notes="X3 NIC: MTU can be configured to be between 576 and 1960 bytes">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env">VAR.env.peer2peer</arg>
+        <arg name="mtu">9000</arg>
+        <arg name="tx"/>
+        <arg name="gso_on"/>
+        <arg name="tso_on">TRUE</arg>
+        <arg name="pkt_size"/>
+        <arg name="sends_num"/>
+        <notes/>
+        <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="NET-44" notes="X3 NIC: MTU can be configured to be between 576 and 1960 bytes">
+          <result value="FAILED">
+            <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env">VAR.env.peer2peer_ipv6</arg>
+        <arg name="mtu">9000</arg>
+        <arg name="tx"/>
+        <arg name="gso_on"/>
+        <arg name="tso_on">TRUE</arg>
+        <arg name="pkt_size"/>
+        <arg name="sends_num"/>
+        <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
           <result value="FAILED">
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -12,27 +12,27 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="i40e&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="intel/i40e module has no version information">
+        <results tags="i40e&amp;linux-mm&gt;508" key="NO-MOD-VERSOIN" notes="intel/i40e module has no version information">
           <result value="PASSED">
             <verdict>Module i40e has no version information</verdict>
           </result>
         </results>
-        <results tags="ice&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="intel/ice module has no version information">
+        <results tags="ice&amp;linux-mm&gt;508" key="NO-MOD-VERSOIN" notes="intel/ice module has no version information">
           <result value="PASSED">
             <verdict>Module ice has no version information</verdict>
           </result>
         </results>
-        <results tags="igb&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="igb module has no version information">
+        <results tags="igb&amp;linux-mm&gt;508" key="NO-MOD-VERSOIN" notes="igb module has no version information">
           <result value="PASSED">
             <verdict>Module igb has no version information</verdict>
           </result>
         </results>
-        <results tags="mlx5_core&amp;linux-mm&gt;510" key="WONTFIX MOD-VERSION">
+        <results tags="mlx5_core&amp;linux-mm&gt;510" key="NO-MOD-VERSOIN">
           <result value="PASSED">
             <verdict>Module mlx5_core has no version information</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-NET-VERSION" notes="VirtIO net module has no version information">
+        <results tags="virtio-pci" key="NO-MOD-VERSOIN" notes="VirtIO net module has no version information">
           <result value="PASSED">
             <verdict>Module virtio_net has no version information</verdict>
           </result>
@@ -48,27 +48,27 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -80,27 +80,27 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -112,27 +112,27 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -144,27 +144,27 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -176,27 +176,27 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -208,27 +208,27 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -246,27 +246,27 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -319,27 +319,27 @@
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX SYSFS-DEBUG" notes="intel/i40e does not provide debug in sysfs">
+        <results tags="i40e" key="NO-SYSFS-DEBUG" notes="intel/i40e does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX SYSFS-DEBUG" notes="ice does not provide debug in sysfs">
+        <results tags="ice" key="NO-SYSFS-DEBUG" notes="ice does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-SYSFS-DEBUG" notes="igb does not provide debug in sysfs">
+        <results tags="igb" key="NO-SYSFS-DEBUG" notes="igb does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-SYSFS-DEBUG" notes="mlx5_core does not provide debug in sysfs, it uses mlx5 instead">
+        <results tags="mlx5_core" key="NO-SYSFS-DEBUG" notes="mlx5_core does not provide debug in sysfs, it uses mlx5 instead">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-SYSFS-DEBUG" notes="VirtIO net does not provide debug in sysfs">
+        <results tags="virtio-pci" key="NO-SYSFS-DEBUG" notes="VirtIO net does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
@@ -368,7 +368,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -388,7 +388,7 @@
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -413,7 +413,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -433,7 +433,7 @@
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -458,7 +458,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -478,7 +478,7 @@
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -513,7 +513,7 @@
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -538,7 +538,7 @@
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -573,7 +573,7 @@
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -598,7 +598,7 @@
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -27,6 +27,11 @@
             <verdict>Module igb has no version information</verdict>
           </result>
         </results>
+        <results tags="mlx5_core&amp;linux-mm&gt;510" key="WONTFIX MOD-VERSION">
+          <result value="SKIPPED">
+            <verdict>Module igb has no version information</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="WONTFIX VIRTIO-NET-VERSION" notes="VirtIO net module has no version information">
           <result value="PASSED">
             <verdict>Module virtio_net has no version information</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -801,11 +801,6 @@
         <arg name="tx"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="i40e" key="I40E-MCAST-JOIN-DELAY" notes="intel/i40e losses up to 2 first packet just after multicast join">
-          <result value="PASSED">
-            <verdict>Few leading multicast packets are not received</verdict>
-          </result>
-        </results>
         <results tags="sfc_ef100" key="SWNETLINUX-4592" notes="UDP multicast is not received">
           <result value="FAILED">
             <verdict>Checking multicast sending: receiver did not become readable</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -12,17 +12,17 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX MOD-VERSION" notes="intel/i40e module has no version information">
+        <results tags="i40e&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="intel/i40e module has no version information">
           <result value="PASSED">
             <verdict>Module i40e has no version information</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX MOD-VERSION" notes="intel/ice module has no version information">
+        <results tags="ice&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="intel/ice module has no version information">
           <result value="PASSED">
             <verdict>Module ice has no version information</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-VERSION" notes="igb module has no version information">
+        <results tags="igb&amp;linux-mm&gt;508" key="WONTFIX MOD-VERSION" notes="igb module has no version information">
           <result value="PASSED">
             <verdict>Module igb has no version information</verdict>
           </result>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -33,6 +33,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -60,6 +65,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -87,6 +97,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -114,6 +129,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -141,6 +161,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -168,6 +193,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -201,6 +231,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -28,7 +28,7 @@
           </result>
         </results>
         <results tags="mlx5_core&amp;linux-mm&gt;510" key="WONTFIX MOD-VERSION">
-          <result value="SKIPPED">
+          <result value="PASSED">
             <verdict>Module igb has no version information</verdict>
           </result>
         </results>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -33,6 +33,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -55,6 +60,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -77,6 +87,11 @@
         <arg name="sock_type"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -99,6 +114,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -121,6 +141,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -143,6 +168,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">FALSE</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -171,6 +201,11 @@
         <arg name="sock_type"/>
         <arg name="if_down">TRUE</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_coredoes not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -269,6 +269,11 @@
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
           </result>
         </results>
+        <results tags="ice" key="WONTFIX SYSFS-DEBUG" notes="ice does not provide debug in sysfs">
+          <result value="FAILED">
+            <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-SYSFS-DEBUG" notes="igb does not provide debug in sysfs">
           <result value="FAILED">
             <verdict>driver/interface subdirectory cannot be opened in /sys/kernel/debug/</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -378,7 +378,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -423,7 +423,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -468,7 +468,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -523,7 +523,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -583,7 +583,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>
@@ -668,7 +668,7 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -12,6 +12,16 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX MOD-VERSION" notes="intel/i40e module has no version information">
+          <result value="PASSED">
+            <verdict>Module i40e has no version information</verdict>
+          </result>
+        </results>
+        <results tags="ice" key="WONTFIX MOD-VERSION" notes="intel/ice module has no version information">
+          <result value="PASSED">
+            <verdict>Module ice has no version information</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-VERSION" notes="igb module has no version information">
           <result value="PASSED">
             <verdict>Module igb has no version information</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -323,6 +323,11 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
@@ -363,6 +368,11 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
@@ -403,6 +413,11 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx_efct" key="WONTFIX X3-TSO" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
@@ -453,6 +468,11 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
           <result value="FAILED">
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>
@@ -508,6 +528,11 @@
         <arg name="pkt_size"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx-virtio-net" key="XILINX-VIRTIO-MTU" notes="Xilinx VirtIO net does not allow MTU change">
           <result value="FAILED">
             <verdict>Failed to set MTU on IUT, rc=TA_UNIX-EINVAL</verdict>

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -801,6 +801,11 @@
         <arg name="tx"/>
         <arg name="sends_num"/>
         <notes/>
+        <results tags="i40e" key="I40E-MCAST-JOIN-DELAY" notes="intel/i40e losses up to 2 first packet just after multicast join">
+          <result value="PASSED">
+            <verdict>Few leading multicast packets are not received</verdict>
+          </result>
+        </results>
         <results tags="sfc_ef100" key="SWNETLINUX-4592" notes="UDP multicast is not received">
           <result value="FAILED">
             <verdict>Checking multicast sending: receiver did not become readable</verdict>

--- a/trc/devlink.xml
+++ b/trc/devlink.xml
@@ -13,6 +13,11 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>dist_layout parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
@@ -46,6 +51,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>ct_thresh parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
@@ -80,6 +90,11 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>separated_cpu parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>

--- a/trc/devlink.xml
+++ b/trc/devlink.xml
@@ -13,32 +13,32 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+        <results tags="i40e" key="NO-DEVLINK" notes="intel/i40e does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+        <results tags="ice" key="NO-DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
+        <results tags="igb" key="NO-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-DEVLINK" notes="mlx5_core does not provide devlink parameters">
+        <results tags="mlx5_core" key="NO-DEVLINK" notes="mlx5_core does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
         </results>
-        <results tags="sfc|sfc_ef100" key="WONTFIX SFC-DEVLINK" notes="sfc does not provide devlink parameters">
+        <results tags="sfc|sfc_ef100" key="NO-DEVLINK" notes="sfc does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
+        <results tags="virtio-pci" key="NO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
           </result>
@@ -51,32 +51,32 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+        <results tags="i40e" key="NO-DEVLINK" notes="intel/i40e does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+        <results tags="ice" key="NO-DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
+        <results tags="igb" key="NO-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-DEVLINK" notes="mlx5_core does not provide devlink parameters">
+        <results tags="mlx5_core" key="NO-DEVLINK" notes="mlx5_core does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
         </results>
-        <results tags="sfc|sfc_ef100" key="WONTFIX SFC-DEVLINK" notes="sfc does not provide devlink parameters">
+        <results tags="sfc|sfc_ef100" key="NO-DEVLINK" notes="sfc does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
+        <results tags="virtio-pci" key="NO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
           </result>
@@ -90,32 +90,32 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX DEVLINK" notes="intel/i40e does not provide devlink parameters">
+        <results tags="i40e" key="NO-DEVLINK" notes="intel/i40e does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+        <results tags="ice" key="NO-DEVLINK" notes="ice does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
+        <results tags="igb" key="NO-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-DEVLINK" notes="mlx5_core does not provide devlink parameters">
+        <results tags="mlx5_core" key="NO-DEVLINK" notes="mlx5_core does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>
         </results>
-        <results tags="sfc|sfc_ef100" key="WONTFIX SFC-DEVLINK" notes="sfc does not provide devlink parameters">
+        <results tags="sfc|sfc_ef100" key="NO-DEVLINK" notes="sfc does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
+        <results tags="virtio-pci" key="NO-DEVLINK" notes="VirtIO net does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>
           </result>

--- a/trc/devlink.xml
+++ b/trc/devlink.xml
@@ -13,6 +13,11 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>dist_layout parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>dist_layout parameter is not present</verdict>
@@ -41,6 +46,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>ct_thresh parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>ct_thresh parameter is not present</verdict>
@@ -70,6 +80,11 @@
         <arg name="env"/>
         <arg name="if_down"/>
         <notes/>
+        <results tags="ice" key="WONTFIX DEVLINK" notes="ice does not provide devlink parameters">
+          <result value="SKIPPED">
+            <verdict>separated_cpu parameter is not present</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-DEVLINK" notes="igb does not provide devlink parameters">
           <result value="SKIPPED">
             <verdict>separated_cpu parameter is not present</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -53,6 +53,11 @@
         <arg name="env"/>
         <arg name="flags">MAC</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -78,6 +83,11 @@
         <arg name="env"/>
         <arg name="flags">DEDICATED</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -103,6 +113,11 @@
         <arg name="env"/>
         <arg name="flags">SHARED_MAC|SHARED_PHY</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -128,6 +143,11 @@
         <arg name="env"/>
         <arg name="flags">ALL</arg>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -29,6 +29,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX ETHTOOL-MSGLVL" notes="intel/i40e does not have logs enabled via msglvl">
+          <result value="FAILED">
+            <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX ETHTOOL-MSGLVL" notes="ice does not have logs enabled via msglvl">
           <result value="FAILED">
             <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
@@ -206,6 +211,12 @@
             <verdict>Preset maximums RX: 256, TX: 256</verdict>
           </result>
         </results>
+        <results tags="i40e">
+          <result value="PASSED">
+            <verdict>Current ring sizes RX: 512, TX: 512</verdict>
+            <verdict>Preset maximums RX: 4096, TX: 4096</verdict>
+          </result>
+        </results>
         <results tags="ice">
           <result value="PASSED">
             <verdict>Current ring sizes RX: 2048, TX: 256</verdict>
@@ -242,6 +253,11 @@
             <verdict>Pause autonegotiation is disabled</verdict>
           </result>
         </results>
+        <results tags="i40e">
+          <result value="PASSED">
+            <verdict>Pause autonegotiation is disabled</verdict>
+          </result>
+        </results>
         <results tags="ice">
           <result value="PASSED">
             <verdict>Pause autonegotiation is disabled</verdict>
@@ -260,6 +276,12 @@
         <results tags="mlx5_core" key="NO-SW-TS">
           <result value="PASSED">
             <verdict>Some of the expected software timestamps flags are not set: SOF_TIMESTAMPING_TX_SOFTWARE | SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1572">
+          <result value="PASSED">
+            <verdict>Some of the expected RX filters flags are not set: HWTSTAMP_FILTER_ALL</verdict>
+            <verdict>Additional RX filters flags are reported: HWTSTAMP_FILTER_ALL</verdict>
           </result>
         </results>
         <results tags="ice">

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -289,7 +289,7 @@
             <verdict>Additional RX filters flags are reported: HWTSTAMP_FILTER_ALL</verdict>
           </result>
         </results>
-        <results tags="ice">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="PASSED">
             <verdict>No PHC device index is specified</verdict>
             <verdict>Some of the expected TX types flags are not set: HWTSTAMP_TX_OFF | HWTSTAMP_TX_ON</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -29,6 +29,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-MSGLVL" notes="ice does not have logs enabled via msglvl">
+          <result value="FAILED">
+            <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-MSGLVL" notes="igb does not have logs enabled via msglvl">
           <result value="FAILED">
             <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
@@ -181,6 +186,12 @@
             <verdict>Preset maximums RX: 256, TX: 256</verdict>
           </result>
         </results>
+        <results tags="ice">
+          <result value="PASSED">
+            <verdict>Current ring sizes RX: 2048, TX: 256</verdict>
+            <verdict>Preset maximums RX: 8160, TX: 8160</verdict>
+          </result>
+        </results>
         <results tags="igb">
           <result value="PASSED">
             <verdict>Current ring sizes RX: 256, TX: 256</verdict>
@@ -211,6 +222,13 @@
             <verdict>Pause autonegotiation is disabled</verdict>
           </result>
         </results>
+        <results tags="ice">
+          <result value="PASSED">
+            <verdict>Pause autonegotiation is disabled</verdict>
+            <verdict>Reception of pause frames is disabled</verdict>
+            <verdict>Transmission of pause frames is disabled</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="ts_info" type="script">
@@ -222,6 +240,14 @@
         <results tags="mlx5_core" key="NO-SW-TS">
           <result value="PASSED">
             <verdict>Some of the expected software timestamps flags are not set: SOF_TIMESTAMPING_TX_SOFTWARE | SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE</verdict>
+          </result>
+        </results>
+        <results tags="ice">
+          <result value="PASSED">
+            <verdict>No PHC device index is specified</verdict>
+            <verdict>Some of the expected TX types flags are not set: HWTSTAMP_TX_OFF | HWTSTAMP_TX_ON</verdict>
+            <verdict>Some of the expected RX filters flags are not set: HWTSTAMP_FILTER_NONE | HWTSTAMP_FILTER_ALL</verdict>
+            <verdict>Some of the expected harware timestamps flags are not set: SOF_TIMESTAMPING_TX_HARDWARE | SOF_TIMESTAMPING_RX_HARDWARE | SOF_TIMESTAMPING_RAW_HARDWARE</verdict>
           </result>
         </results>
       </iter>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -29,27 +29,27 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-MSGLVL" notes="intel/i40e does not have logs enabled via msglvl">
+        <results tags="i40e" key="NO-ETHTOOL-MSGLVL" notes="intel/i40e does not have logs enabled via msglvl">
           <result value="FAILED">
             <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-MSGLVL" notes="ice does not have logs enabled via msglvl">
+        <results tags="ice" key="NO-ETHTOOL-MSGLVL" notes="ice does not have logs enabled via msglvl">
           <result value="FAILED">
             <verdict>Some logs from driver were detected when msglvl is set to zero</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-MSGLVL" notes="igb does not have logs enabled via msglvl">
+        <results tags="igb" key="NO-ETHTOOL-MSGLVL" notes="igb does not have logs enabled via msglvl">
           <result value="FAILED">
             <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX ETHTOOL-MSGLVL">
+        <results tags="mlx5_core" key="NO-ETHTOOL-MSGLVL">
           <result value="FAILED">
             <verdict>Some logs from driver were detected when msglvl is set to zero</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-MSGLEVEL" notes="VirtIO net does not support message level change via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-MSGLVL" notes="VirtIO net does not support message level change via ethtool">
           <result value="FAILED">
             <verdict>Failed to enable all flags in msglvl</verdict>
           </result>
@@ -63,27 +63,27 @@
         <arg name="env"/>
         <arg name="flags">MAC</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -93,27 +93,27 @@
         <arg name="env"/>
         <arg name="flags">DEDICATED</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -123,27 +123,27 @@
         <arg name="env"/>
         <arg name="flags">SHARED_MAC|SHARED_PHY</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -153,27 +153,27 @@
         <arg name="env"/>
         <arg name="flags">ALL</arg>
         <notes/>
-        <results tags="i40e" key="WONTFIX ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
+        <results tags="i40e" key="NO-ETHTOOL-RESET" notes="intel/i40e does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+        <results tags="ice" key="NO-ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
+        <results tags="igb" key="NO-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
+        <results tags="mlx5_core" key="NO-ETHTOOL-RESET" notes="mlx5_core does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
+        <results tags="virtio-pci" key="NO-ETHTOOL-RESET" notes="VirtIO net does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
           </result>
@@ -289,7 +289,7 @@
             <verdict>Additional RX filters flags are reported: HWTSTAMP_FILTER_ALL</verdict>
           </result>
         </results>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="PASSED">
             <verdict>No PHC device index is specified</verdict>
             <verdict>Some of the expected TX types flags are not set: HWTSTAMP_TX_OFF | HWTSTAMP_TX_ON</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -44,6 +44,11 @@
             <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
           </result>
         </results>
+        <results tags="mlx5_core" key="WONTFIX ETHTOOL-MSGLVL">
+          <result value="FAILED">
+            <verdict>Some logs from driver were detected when msglvl is set to zero</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="WONTFIX VIRTIO-ETHTOOL-MSGLEVEL" notes="VirtIO net does not support message level change via ethtool">
           <result value="FAILED">
             <verdict>Failed to enable all flags in msglvl</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -48,6 +48,11 @@
         <arg name="env"/>
         <arg name="flags">MAC</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -68,6 +73,11 @@
         <arg name="env"/>
         <arg name="flags">DEDICATED</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -88,6 +98,11 @@
         <arg name="env"/>
         <arg name="flags">SHARED_MAC|SHARED_PHY</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>
@@ -108,6 +123,11 @@
         <arg name="env"/>
         <arg name="flags">ALL</arg>
         <notes/>
+        <results tags="ice" key="WONTFIX ETHTOOL-RESET" notes="intel/ice does not support reset via ethtool">
+          <result value="SKIPPED">
+            <verdict>ETHTOOL_RESET is not supported</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-RESET" notes="igb does not support reset via ethtool">
           <result value="SKIPPED">
             <verdict>ETHTOOL_RESET is not supported</verdict>

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -36,7 +36,7 @@
         </results>
         <results tags="ice" key="WONTFIX ETHTOOL-MSGLVL" notes="ice does not have logs enabled via msglvl">
           <result value="FAILED">
-            <verdict>No logs from the driver were detected when all flags in msglvl are switched on</verdict>
+            <verdict>Some logs from driver were detected when msglvl is set to zero</verdict>
           </result>
         </results>
         <results tags="igb" key="WONTFIX IGB-ETHTOOL-MSGLVL" notes="igb does not have logs enabled via msglvl">

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -199,6 +199,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="mlx5_core" key="NO-SW-TS">
+          <result value="PASSED">
+            <verdict>Some of the expected software timestamps flags are not set: SOF_TIMESTAMPING_TX_SOFTWARE | SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -124,6 +124,11 @@
         <arg name="gro_on"/>
         <arg name="gro_hw_on">TRUE</arg>
         <notes/>
+        <results tags="ice" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
@@ -143,6 +148,11 @@
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -180,6 +190,11 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
+        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
@@ -211,6 +226,11 @@
         <arg name="gro_on"/>
         <arg name="gro_hw_on">TRUE</arg>
         <notes/>
+        <results tags="ice" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
@@ -225,6 +245,11 @@
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -258,6 +283,11 @@
           </result>
         </results>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -124,6 +124,11 @@
         <arg name="gro_on"/>
         <arg name="gro_hw_on">TRUE</arg>
         <notes/>
+        <results tags="i40e" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="ice" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
@@ -148,6 +153,11 @@
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -190,6 +200,11 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
+        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
@@ -226,6 +241,11 @@
         <arg name="gro_on"/>
         <arg name="gro_hw_on">TRUE</arg>
         <notes/>
+        <results tags="i40e" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="ice" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
@@ -245,6 +265,11 @@
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -283,6 +308,11 @@
           </result>
         </results>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -104,8 +104,26 @@
         <arg name="rx_csum_on">FALSE</arg>
         <arg name="lro_on">FALSE</arg>
         <arg name="gro_on"/>
-        <arg name="gro_hw_on"/>
+        <arg name="gro_hw_on">FALSE</arg>
         <notes/>
+        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="rx_csum_on">FALSE</arg>
+        <arg name="lro_on">FALSE</arg>
+        <arg name="gro_on"/>
+        <arg name="gro_hw_on">TRUE</arg>
+        <notes/>
+        <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
@@ -117,8 +135,41 @@
         <arg name="rx_csum_on">FALSE</arg>
         <arg name="lro_on">TRUE</arg>
         <arg name="gro_on"/>
-        <arg name="gro_hw_on"/>
+        <arg name="gro_hw_on">FALSE</arg>
         <notes/>
+        <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="rx_csum_on">FALSE</arg>
+        <arg name="lro_on">TRUE</arg>
+        <arg name="gro_on"/>
+        <arg name="gro_hw_on">TRUE</arg>
+        <notes/>
+        <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
@@ -145,16 +196,62 @@
         <arg name="rx_csum_on">TRUE</arg>
         <arg name="lro_on">FALSE</arg>
         <arg name="gro_on"/>
-        <arg name="gro_hw_on"/>
+        <arg name="gro_hw_on">FALSE</arg>
         <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="rx_csum_on">TRUE</arg>
+        <arg name="lro_on">FALSE</arg>
+        <arg name="gro_on"/>
+        <arg name="gro_hw_on">TRUE</arg>
+        <notes/>
+        <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
         <arg name="rx_csum_on">TRUE</arg>
         <arg name="lro_on">TRUE</arg>
         <arg name="gro_on"/>
-        <arg name="gro_hw_on"/>
+        <arg name="gro_hw_on">FALSE</arg>
         <notes/>
+        <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-LRO" notes="VirtIO net does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="rx_csum_on">TRUE</arg>
+        <arg name="lro_on">TRUE</arg>
+        <arg name="gro_on"/>
+        <arg name="gro_hw_on">TRUE</arg>
+        <notes/>
+        <results tags="mlx5_core" key="NO-RX-GRO-HW" notes="rx-gro-hw offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -149,7 +149,50 @@
         <arg name="env"/>
         <arg name="rx_csum_on">FALSE</arg>
         <arg name="lro_on">TRUE</arg>
-        <arg name="gro_on"/>
+        <arg name="gro_on">FALSE</arg>
+        <arg name="gro_hw_on">FALSE</arg>
+        <notes/>
+        <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="mlx5_core" key="LRO-WO-RX-CKSUM" notes="LRO works on mlx5 without Rx checksum offload enabled">
+          <result value="PASSED">
+            <verdict>Some packets are coalesced when LRO is enabled even if Rx checksumming is turned off</verdict>
+          </result>
+        </results>
+        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
+          </result>
+        </results>
+        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="rx_csum_on">FALSE</arg>
+        <arg name="lro_on">TRUE</arg>
+        <arg name="gro_on">TRUE</arg>
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
         <results tags="sfc_ef100" key="WONTFIX SWNETLINUX-4593" notes="sfc_ef100 does not support LRO">

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -89,6 +89,11 @@
             <verdict>Feature 'rx-gro-hw' is enabled and cannot be modified</verdict>
           </result>
         </results>
+        <results tags="ice" key="TSO6">
+          <result value="SKIPPED">
+            <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="xilinx_efct" notes="TCP segmentation offload will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -89,7 +89,7 @@
             <verdict>Feature 'rx-gro-hw' is enabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="TSO6">
+        <results tags="ice&amp;linux-mm&lt;508" key="TSO6">
           <result value="SKIPPED">
             <verdict>Feature 'tx-tcp6-segmentation' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/offload.xml
+++ b/trc/offload.xml
@@ -14,7 +14,7 @@
         <arg name="sock_type"/>
         <arg name="rx_csum">FALSE</arg>
         <notes/>
-        <results tags="xilinx_efct" key="WONTFIX X3-TX-CKSUM" notes="TCP/IP checksum offload on transmit will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TX-CKSUM" notes="TCP/IP checksum offload on transmit will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-checksum-ip-generic' cannot be modified</verdict>
           </result>
@@ -25,7 +25,7 @@
         <arg name="sock_type"/>
         <arg name="rx_csum">FALSE</arg>
         <notes/>
-        <results tags="xilinx_efct" key="WONTFIX X3-TX-CKSUM" notes="TCP/IP checksum offload on transmit will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-TX-CKSUM" notes="TCP/IP checksum offload on transmit will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'tx-checksum-ip-generic' cannot be modified</verdict>
           </result>
@@ -36,7 +36,7 @@
         <arg name="sock_type"/>
         <arg name="rx_csum">TRUE</arg>
         <notes/>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' cannot be modified</verdict>
           </result>
@@ -53,7 +53,7 @@
         <arg name="max_size"/>
         <arg name="send_calls"/>
         <notes/>
-        <results tags="peer-virtio_pci" key="WONTFIX VIRTIO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
+        <results tags="peer-virtio_pci" key="NO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is enabled and cannot be modified</verdict>
           </result>
@@ -66,7 +66,7 @@
         <arg name="max_size"/>
         <arg name="send_calls"/>
         <notes/>
-        <results tags="peer-virtio_pci" key="WONTFIX VIRTIO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
+        <results tags="peer-virtio_pci" key="NO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is enabled and cannot be modified</verdict>
           </result>
@@ -84,7 +84,7 @@
         <arg name="max_size"/>
         <arg name="send_calls"/>
         <notes/>
-        <results tags="peer-virtio_pci" key="WONTFIX VIRTIO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
+        <results tags="peer-virtio_pci" key="NO-RX-GRO-HW" notes="VirtIO net does not support hardware GRO disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-gro-hw' is enabled and cannot be modified</verdict>
           </result>
@@ -111,7 +111,7 @@
         <arg name="gro_on"/>
         <arg name="gro_hw_on">FALSE</arg>
         <notes/>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
           </result>
@@ -139,7 +139,7 @@
             <verdict>Feature 'rx-gro-hw' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
           </result>
@@ -157,17 +157,17 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="i40e" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="ice" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+        <results tags="igb" key="NO-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -177,12 +177,12 @@
             <verdict>Some packets are coalesced when LRO is enabled even if Rx checksumming is turned off</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-RX-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -200,27 +200,27 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="i40e" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="ice" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+        <results tags="igb" key="NO-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-RX-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -243,27 +243,27 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="i40e" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="ice" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+        <results tags="igb" key="NO-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
+        <results tags="virtio-pci" key="NO-RX-CKSUM" notes="VirtIO net does not support Rx checksum offload disabling">
           <result value="SKIPPED">
             <verdict>Feature 'rx-checksum' is enabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-RX-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -312,27 +312,27 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="i40e" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="ice" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+        <results tags="igb" key="NO-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-LRO" notes="VirtIO net does not support LRO">
+        <results tags="virtio-pci" key="NO-RX-LRO" notes="VirtIO net does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-RX-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
@@ -355,27 +355,27 @@
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="i40e" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="i40e" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-LRO" notes="rx-lro offload is not supported">
+        <results tags="ice" key="NO-RX-LRO" notes="rx-lro offload is not supported">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-LRO" notes="igb does not support LRO">
+        <results tags="igb" key="NO-RX-LRO" notes="igb does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-LRO" notes="VirtIO net does not support LRO">
+        <results tags="virtio-pci" key="NO-RX-LRO" notes="VirtIO net does not support LRO">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
+        <results tags="xilinx_efct" key="NO-RX-LRO" notes="LRO (large receive offload) will not be implemented: XN-200494-PD-1D/KD-070">
           <result value="SKIPPED">
             <verdict>Feature 'rx-lro' is disabled and cannot be modified</verdict>
           </result>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -228,12 +228,12 @@
         <notes/>
         <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
-            <verdict>PTP device index is not known</verdict>
+            <verdict>IUT: PTP device index is not known</verdict>
           </result>
         </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
-            <verdict>PTP device index is not known</verdict>
+            <verdict>IUT: PTP device index is not known</verdict>
           </result>
         </results>
       </iter>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -187,6 +187,11 @@
             <verdict>PTP device index is not known</verdict>
           </result>
         </results>
+        <results tags="ice&amp;linux-mm&gt;=514" key="NO-PTP_SYS_OFFSET_PRECISE">
+          <result value="SKIPPED">
+            <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>
+          </result>
+        </results>
         <results tags="i40e" key="NO-PTP_SYS_OFFSET_PRECISE">
           <result value="SKIPPED">
             <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -14,6 +14,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="set_time" type="script">
@@ -25,6 +30,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="adj_setoffset" type="script">
@@ -36,6 +46,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="adj_frequency" type="script">
@@ -47,6 +62,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="clock_caps" type="script">
@@ -55,6 +75,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="xilinx_efct" key="X3-893">
           <result value="PASSED">
             <verdict>Frequency adjustment range is less than expected</verdict>
@@ -70,6 +95,11 @@
         <arg name="master_cfg"/>
         <arg name="slave_cfg"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="sys_offset" type="script">
@@ -79,6 +109,11 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="sys_offset_extended" type="script">
@@ -88,6 +123,11 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="sys_offset_precise" type="script">
@@ -96,6 +136,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="ptp4l" type="script">
@@ -104,6 +149,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -14,7 +14,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -35,7 +35,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -56,7 +56,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -77,7 +77,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -95,18 +95,18 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX PTP">
+        <results tags="i40e" key="NO-PTP">
           <result value="PASSED">
             <verdict>No external timestamp channels</verdict>
             <verdict>Pulse Per Second is not supported</verdict>
           </result>
         </results>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
         </results>
-        <results tags="ice&amp;linux-mm&gt;=514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&gt;=514" key="NO-PTP">
           <result value="PASSED">
             <verdict>Pulse Per Second is not supported</verdict>
           </result>
@@ -137,7 +137,7 @@
         <arg name="master_cfg"/>
         <arg name="slave_cfg"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -156,7 +156,7 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -175,7 +175,7 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -193,7 +193,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -226,7 +226,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="NO-PTP">
           <result value="SKIPPED">
             <verdict>IUT: PTP device index is not known</verdict>
           </result>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -100,6 +100,11 @@
             <verdict>PTP device index is not known</verdict>
           </result>
         </results>
+        <results tags="ice&amp;linux-mm&gt;=514" key="WONTFIX PTP">
+          <result value="PASSED">
+            <verdict>Pulse Per Second is not supported</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="CLOCK-CAPS">
           <result value="PASSED">
             <verdict>No external timestamp channels</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -75,6 +75,12 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="mlx5_core" key="CLOCK-CAPS">
+          <result value="PASSED">
+            <verdict>No external timestamp channels</verdict>
+            <verdict>Pulse Per Second is not supported</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -136,6 +136,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="mlx5_core" key="NO-PTP_SYS_OFFSET_PRECISE">
+          <result value="SKIPPED">
+            <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -95,6 +95,12 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX PTP">
+          <result value="PASSED">
+            <verdict>No external timestamp channels</verdict>
+            <verdict>Pulse Per Second is not supported</verdict>
+          </result>
+        </results>
         <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -14,7 +14,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -35,7 +35,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -56,7 +56,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -77,7 +77,7 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -95,7 +95,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -126,7 +126,7 @@
         <arg name="master_cfg"/>
         <arg name="slave_cfg"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -145,7 +145,7 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -164,7 +164,7 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -182,7 +182,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>
@@ -210,7 +210,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+        <results tags="ice&amp;linux-mm&lt;514" key="WONTFIX PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
           </result>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -187,6 +187,11 @@
             <verdict>PTP device index is not known</verdict>
           </result>
         </results>
+        <results tags="i40e" key="NO-PTP_SYS_OFFSET_PRECISE">
+          <result value="SKIPPED">
+            <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="NO-PTP_SYS_OFFSET_PRECISE">
           <result value="SKIPPED">
             <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>

--- a/trc/ptp.xml
+++ b/trc/ptp.xml
@@ -14,6 +14,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -30,6 +35,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -46,6 +56,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -62,6 +77,11 @@
         <arg name="min_sleep"/>
         <arg name="max_sleep"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -75,6 +95,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="CLOCK-CAPS">
           <result value="PASSED">
             <verdict>No external timestamp channels</verdict>
@@ -101,6 +126,11 @@
         <arg name="master_cfg"/>
         <arg name="slave_cfg"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -115,6 +145,11 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -129,6 +164,11 @@
         <arg name="env"/>
         <arg name="n_samples"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>
@@ -142,6 +182,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="mlx5_core" key="NO-PTP_SYS_OFFSET_PRECISE">
           <result value="SKIPPED">
             <verdict>PTP_SYS_OFFSET_PRECISE request is not supported</verdict>
@@ -160,6 +205,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="pci-8086-159b" key="WONTFIX PTP" notes="E810-XXVDA2 has no PTP">
+          <result value="SKIPPED">
+            <verdict>PTP device index is not known</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-PTP" notes="Virtio does not support PTP">
           <result value="SKIPPED">
             <verdict>PTP device index is not known</verdict>

--- a/trc/rss.xml
+++ b/trc/rss.xml
@@ -12,12 +12,12 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-NET-PCI" notes="VirtIO net does not support RSS">
+        <results tags="virtio-pci" key="NO-RSS" notes="VirtIO net does not support RSS">
           <result value="SKIPPED">
             <verdict>RSS is not supported for IUT interface</verdict>
           </result>
         </results>
-        <results tags="mlx5_core" key="WONTFIX MLX5-TOEPLITZ" notes="Mellanox uses nonstandard Toeplitz hash algorithm">
+        <results tags="mlx5_core" key="MLX5-SYM-TOEPLITZ" notes="Mellanox uses nonstandard Toeplitz hash algorithm">
           <result value="PASSED">
             <verdict>NIC uses symmetric-or-xor Toeplitz hash</verdict>
           </result>

--- a/trc/rss.xml
+++ b/trc/rss.xml
@@ -17,6 +17,11 @@
             <verdict>RSS is not supported for IUT interface</verdict>
           </result>
         </results>
+        <results tags="mlx5_core" key="WONTFIX MLX5-TOEPLITZ" notes="Mellanox uses nonstandard Toeplitz hash algorithm">
+          <result value="PASSED">
+            <verdict>NIC uses symmetric-or-xor Toeplitz hash</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="epilogue" type="script">

--- a/trc/rx_path.xml
+++ b/trc/rx_path.xml
@@ -22,6 +22,11 @@
         <arg name="rx_fcs">TRUE</arg>
         <arg name="small_frame"/>
         <notes/>
+        <results tags="ice" key="WONTFIX RX-FCS" notes="intel/ice does not support FCS on Rx">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="igb" key="WONTFIX IGB-RX-FCS" notes="igb does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>

--- a/trc/rx_path.xml
+++ b/trc/rx_path.xml
@@ -22,27 +22,27 @@
         <arg name="rx_fcs">TRUE</arg>
         <arg name="small_frame"/>
         <notes/>
-        <results tags="i40e" key="WONTFIX RX-FCS" notes="intel/i40e does not support FCS on Rx">
+        <results tags="i40e" key="NO-RX-FCS" notes="intel/i40e does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="ice" key="WONTFIX RX-FCS" notes="intel/ice does not support FCS on Rx">
+        <results tags="ice" key="NO-RX-FCS" notes="intel/ice does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="igb" key="WONTFIX IGB-RX-FCS" notes="igb does not support FCS on Rx">
+        <results tags="igb" key="NO-RX-FCS" notes="igb does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-FCS" notes="VirtIO net does not support FCS on Rx">
+        <results tags="virtio-pci" key="NO-RX-FCS" notes="VirtIO net does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
           </result>
         </results>
-        <results tags="xilinx_efct" key="WONTFIX X3-RX-FCS" notes="xilinx_efct does not support FCS on Rx on EA release: XN-200494-PD-1D/NPT-450">
+        <results tags="xilinx_efct" key="NO-RX-FCS" notes="xilinx_efct does not support FCS on Rx on EA release: XN-200494-PD-1D/NPT-450">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
           </result>
@@ -82,7 +82,7 @@
             <verdict>Failed to set use_adaptive_rx_coalesce, rc=CS-ENOENT</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
+        <results tags="virtio-pci" key="NO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
           <result value="SKIPPED">
             <verdict>rx_coalesce_usecs=300 is not supported</verdict>
           </result>
@@ -92,7 +92,7 @@
         <arg name="env"/>
         <arg name="coalesce_usecs">511</arg>
         <notes/>
-        <results tags="ice&amp;linux-mm&lt;506" key="WONTFIX RX-USECS-EVEN" notes="intel/ice requires rx-usecs to be even before Linux 5.6">
+        <results tags="ice&amp;linux-mm&lt;506" key="RX-USECS-EVEN" notes="intel/ice requires rx-usecs to be even before Linux 5.6">
           <result value="FAILED">
             <verdict>Failed to set rx_coalesce_usecs, rc=TA_UNIX-EINVAL</verdict>
           </result>
@@ -102,7 +102,7 @@
             <verdict>Failed to set use_adaptive_rx_coalesce, rc=CS-ENOENT</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
+        <results tags="virtio-pci" key="NO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
           <result value="SKIPPED">
             <verdict>rx_coalesce_usecs=511 is not supported</verdict>
           </result>
@@ -117,7 +117,7 @@
             <verdict>Failed to set use_adaptive_rx_coalesce, rc=CS-ENOENT</verdict>
           </result>
         </results>
-        <results tags="virtio-pci" key="WONTFIX VIRTIO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
+        <results tags="virtio-pci" key="NO-RX-IRQ-MODER-CONTROL" notes="VirtIO net does not support interrupt moderation control">
           <result value="SKIPPED">
             <verdict>rx_coalesce_usecs=800 is not supported</verdict>
           </result>

--- a/trc/rx_path.xml
+++ b/trc/rx_path.xml
@@ -92,6 +92,11 @@
         <arg name="env"/>
         <arg name="coalesce_usecs">511</arg>
         <notes/>
+        <results tags="ice&amp;linux-mm&lt;506" key="WONTFIX RX-USECS-EVEN" notes="intel/ice requires rx-usecs to be even before Linux 5.6">
+          <result value="FAILED">
+            <verdict>Failed to set rx_coalesce_usecs, rc=TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
         <results tags="sfc_ef100" key="SWNETLINUX-3314" notes="ethtool coalesce ops are not implemented in sfc_ef100">
           <result value="FAILED">
             <verdict>Failed to set use_adaptive_rx_coalesce, rc=CS-ENOENT</verdict>

--- a/trc/rx_path.xml
+++ b/trc/rx_path.xml
@@ -22,6 +22,11 @@
         <arg name="rx_fcs">TRUE</arg>
         <arg name="small_frame"/>
         <notes/>
+        <results tags="i40e" key="WONTFIX RX-FCS" notes="intel/i40e does not support FCS on Rx">
+          <result value="SKIPPED">
+            <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>
+          </result>
+        </results>
         <results tags="ice" key="WONTFIX RX-FCS" notes="intel/ice does not support FCS on Rx">
           <result value="SKIPPED">
             <verdict>Feature 'rx-fcs' is disabled and cannot be modified</verdict>


### PR DESCRIPTION
 - fix too long test run because of unnecessary sleep when all data are received
 - improve RSS tests to handle symmetric Toeplitz hash gracefully (requires updates in TE)
 - fill in expectations for Intel i40e, ice and Mellanox mlx5_core drivers
 - improve basic/muticast test to handle race conditions gracefully

Sanity check logs:
https://ts-factory.io/bublik/v2/runs/178517
https://ts-factory.io/bublik/v2/runs/177526
https://ts-factory.io/bublik/v2/runs/177994 (no new regressions despite of huge number of unexpected results because of incorrect tuning of the configuration)
https://ts-factory.io/bublik/v2/runs/178450 (kills test host since reset is buggy in in-tree sfc driver)
https://ts-factory.io/bublik/v2/runs/178492 (the same sfc bug on Linux 5.19 from Debian bullseye backports)