### PR TITLE
Add generic configuration for VM-to-VM testing

### DIFF
--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -21,7 +21,7 @@ TE_LIB_PARMS([tapi_tad], [], [],
 . $TE_BASE/engine/builder/te_ta_ssh_helper
 
 define([TE_AGENT_BUILD], [
-    if test -n "${$1}" -o "${$1_BUILD}" = local ; then
+    if test -n "${$1}" -o -n "${$1_BUILD_HOST}" -o "${$1_BUILD}" = local ; then
         if ! te_is_in_list "${$1_TA_TYPE}" $TE_BS_PLATFORMS ; then
             te_ta_type_as_platform "$1"
 
@@ -128,4 +128,5 @@ define([TE_AGENT_BUILD], [
 
 TE_AGENT_BUILD([TE_IUT])
 TE_AGENT_BUILD([TE_TST1])
+TE_AGENT_BUILD([TE_HYPERVISOR])
 TE_AGENT_BUILD([TE_LOG_LISTENER])

--- a/conf/scripts/export_driver_sources
+++ b/conf/scripts/export_driver_sources
@@ -74,9 +74,9 @@ obtain_driver_sources() {
         x3_net_linux_src="${X3_NET_LINUX_SRC}"
     else
         if test -z "$driver_name" ; then
-            if test "$role" = "TST1" -a "$HWSIM" = "true" ; then
+            if test "$role" = "TST1" ; then
                 echo "INFO: driver name is empty, this is acceptable" \
-                     "for HWSIM + TST1" >&2
+                     "for TST1" >&2
             else
                 fail "driver name is not defined"
             fi

--- a/conf/scripts/ta-def
+++ b/conf/scripts/ta-def
@@ -6,6 +6,7 @@
 
 export TE_IUT_TA_NAME="NetDrv"
 export TE_TST1_TA_NAME="Peer"
+export TE_HYPERVISOR_TA_NAME="Hypervisor"
 export TE_LOG_LISTENER_TA_NAME="LogListener"
 export TE_TA_SIGNATURE_FIELDS="gcc-target kernel-version-full libc-version header-version"
 
@@ -20,11 +21,12 @@ fi
 
 source "${TE_BASE}"/engine/builder/te_ta_ssh_helper
 
-: ${TS_TEST_AGENTS:=TE_IUT TE_TST1 TE_LOG_LISTENER}
+: ${TS_TEST_AGENTS:=TE_IUT TE_TST1 TE_HYPERVISOR TE_LOG_LISTENER}
 
 te_ta_list_detect_type_with_signature ${TS_TEST_AGENTS}
 
 export_headers_num "TE_IUT"
 export_headers_num "TE_TST1"
+export_headers_num "TE_HYPERVISOR"
 export_headers_num "TE_LOG_LISTENER"
 export_kernel_version_num "TE_IUT"

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -263,9 +263,15 @@
             <verdict>Pause autonegotiation is disabled</verdict>
           </result>
         </results>
-        <results tags="ice">
+        <results tags="ice&amp;linux-mm&lt;515">
           <result value="PASSED">
             <verdict>Pause autonegotiation is disabled</verdict>
+            <verdict>Reception of pause frames is disabled</verdict>
+            <verdict>Transmission of pause frames is disabled</verdict>
+          </result>
+        </results>
+        <results tags="ice">
+          <result value="PASSED">
             <verdict>Reception of pause frames is disabled</verdict>
             <verdict>Transmission of pause frames is disabled</verdict>
           </result>


### PR DESCRIPTION
Plus some fixes in TRC and tests to improve stability.

Examples of logs of VM-to-VM testing https://ts-factory.io/bublik/v2/runs/179944 (fixes for mtu_udp and ts_info are under review)

Other examples of testing logs on various NICs:
https://ts-factory.io/bublik/v2/runs/178985
https://ts-factory.io/bublik/v2/runs/179453
https://ts-factory.io/bublik/v2/runs/179921

Logs for sfc without RESET testing and Intel E810 will follow.