### PR TITLE
basic/rx_mode: remove multicast addr after use

### DIFF
--- a/net-drv-ts/basic/rx_mode.c
+++ b/net-drv-ts/basic/rx_mode.c
@@ -252,6 +252,9 @@ main(int argc, char *argv[])
 
 cleanup:
 
+    CLEANUP_CHECK_RC(tapi_cfg_base_if_del_mcast_mac(if_oid,
+                        (const uint8_t *)mcast_addr->sa_data));
+
     CLEANUP_RPC_CLOSE(iut_rpcs, iut_s);
 
     CLEANUP_CHECK_RC(tapi_tad_csap_destroy(iut_rpcs->ta, 0, csap_iut));


### PR DESCRIPTION
Previously, the test did not delete the added multicast address after itself. The test environment also does not perform multicsat address restore with removing the multicast addresses newly added by the test, because of the `volatile: true` flag for the OID
“/agent/interface/mcast_link_addr”. This can cause problems with accumulating a large number of multicast addresses during testing, thus causing collisions. This patch fixes this issue.

Fixes: e19327907e0f ("basic: add Rx mode test")

Reviewed-by: Andrew Rybchenko <andrew.rybchenko@oktetlabs.ru>