### PR TITLE
conf: fix build because of PCRE version change

### DIFF
--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -92,7 +92,7 @@ define([TE_AGENT_BUILD], [
                       [talib_net_drv_ts rpcserver rpcs_job ta_job rpcs_bpf \
                        agentlib rpcxdrta rpc_types rpctransport loggerta \
                        tools logger_core],
-                      [\${EXT_SOURCES}/build.sh --extra-deps='libpcre,libxdp,libbpf'],
+                      [\${EXT_SOURCES}/build.sh --extra-deps='libpcre2-8,libxdp,libbpf'],
                       [ta_rpcs], [])
 
             TE_TA_APP([ta_core_watcher], [${$1_TA_TYPE}], [${$1_TA_TYPE}],


### PR DESCRIPTION
TE now uses libpcre2-8 instead of libpcre.

The changeset is required to switch to TE 1.47.2.