### PR TITLE
jenkins: support external driver sources

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,5 +1,5 @@
 [SPDX-License-Identifier: Apache-2.0]::
-[Copyright (C) 2023 OKTET Labs Ltd. All rights reserved.]::
+[Copyright (C) 2023-2026 OKTET Labs Ltd. All rights reserved.]::
 
 # Jenkins pipelines
 
@@ -56,3 +56,39 @@ Specification for the following pipelines is available here:
   on `teTsPipeline` template.
   Node with label `net-drv-ts` should be configured in Jenkins where
   this pipeline will be run. This test suite will be built and run there.
+
+## Building external driver sources
+
+`update` and `run` can checkout external driver sources and export
+`TE_IUT_NET_DRV_SRC`.
+
+Typical flow:
+
+- driver build job publishes driver revisions;
+- `update` gets revisions from that job via `get_revs_from`;
+- `run` gets revisions from `update`.
+
+Driver may be taken from revision name.
+For example, if loaded revisions contain driver name `somename`, helper uses
+`SOMENAME_GIT_URL` and `SOMENAME_REV`/`SOMENAME_BRANCH`.
+
+For names with non-alphanumeric characters (for example `some-name`),
+helper first tries normalized keys where such characters are replaced with
+`_` and the name is uppercased (`SOME_NAME_*`).
+Raw keys from revisions (`SOME-NAME_*`) are also accepted.
+
+If loaded revisions contain multiple non-core names
+(`te`, `ts`, `tsconf`, `tsrigs` are ignored), choose one via optional
+`net_drv_name` job parameter (or `NET_DRV_NAME` in site-specific defs).
+
+`net_drv_repo` and `net_drv_rev` parameters in `run` / `update` can override
+URL/revision.
+
+If no driver name is found, integration is skipped.
+
+`TE_IUT_NET_DRV_BUILD` may be set directly in
+`jenkins/defs/net-drv-ts/defs.groovy`. Alternatively,
+`NET_DRV_BUILD_SCRIPTS` may be set there as a map with driver
+name used as a key.
+Absolute paths are used as is, relative paths are resolved against
+`TSRIGS_SRC`.

--- a/jenkins/net_drv.groovy
+++ b/jenkins/net_drv.groovy
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+//
+// Helper for checking out external driver sources for net-drv-ts Jenkins jobs.
+
+def getDriverId(ctx, String name) {
+    def raw = (name ?: '').toString().trim()
+
+    if (!raw) {
+        return ''
+    }
+
+    return ctx.teCommon.str2id(raw).toLowerCase()
+}
+
+def getDriverMetaValue(ctx, String drvName, List suffixes, Map vars = null) {
+    def prefixes = []
+    def rawName = (drvName ?: '').toString().trim()
+    def drvId = getDriverId(ctx, rawName)
+
+    if (drvId) {
+        prefixes += "${drvId.toUpperCase()}_"
+    }
+
+    if (rawName) {
+        prefixes += "${rawName.toUpperCase()}_"
+    }
+
+    for (String prefix : prefixes.unique()) {
+        for (String suffix : suffixes) {
+            def varName = "${prefix}${suffix}"
+            def value = (ctx[varName] ?:
+                         ctx.env[varName] ?:
+                         vars?.get(varName) ?: '')
+                        .toString().trim()
+            if (value) {
+                return value
+            }
+        }
+    }
+
+    return ''
+}
+
+def getDriverName(ctx) {
+    def coreComponents = ['te', 'ts', 'tsconf', 'tsrigs'] as Set
+    def candidates = []
+    def allRevs = ctx.all_revs
+    def selected = (ctx.params.net_drv_name ?:
+                    ctx.NET_DRV_NAME ?:
+                    ctx.env.NET_DRV_NAME ?: '').toString().trim()
+
+    if (allRevs instanceof Map) {
+        allRevs.each {
+            name, vars ->
+            def drvName = name?.toString()?.trim()
+            def drvId
+
+            if (!drvName) {
+                return
+            }
+
+            drvId = getDriverId(ctx, drvName)
+            if (coreComponents.contains(drvId)) {
+                return
+            }
+
+            def hasAny = getDriverMetaValue(ctx, drvName,
+                                            ['GIT_URL', 'REV', 'BRANCH'], vars)
+
+            if (!hasAny) {
+                return
+            }
+            candidates += drvId
+        }
+    }
+
+    candidates = candidates.unique()
+
+    if (selected) {
+        selected = getDriverId(ctx, selected)
+        if (!candidates.isEmpty() && !candidates.contains(selected)) {
+            error("NET_DRV_NAME=${selected} is not found in loaded revisions; found: ${candidates.join(', ')}")
+        }
+        return selected
+    }
+
+    if (candidates.size() > 1) {
+        error("Cannot determine driver name from loaded revisions; found: ${candidates.join(', ')}. Set net_drv_name parameter (or NET_DRV_NAME) to pick one.")
+    }
+
+    if (!candidates.isEmpty()) {
+        return candidates[0]
+    }
+
+    return null
+}
+
+def setDriverBuildScript(ctx) {
+    def drvName = getDriverName(ctx)
+
+    if (!drvName) {
+        return
+    }
+
+    if (ctx.TE_IUT_NET_DRV_BUILD ?: ctx.env.TE_IUT_NET_DRV_BUILD) {
+        return
+    }
+
+    def scripts = ctx.NET_DRV_BUILD_SCRIPTS
+    if (!(scripts instanceof Map)) {
+        return
+    }
+
+    def entry = scripts[drvName]
+    if (entry == null) {
+        entry = scripts[getDriverId(ctx, drvName)]
+    }
+    if (entry == null) {
+        return
+    }
+
+    def build = entry.toString().trim()
+
+    if (!build) {
+        return
+    }
+
+    if (!build.startsWith('/')) {
+        def tsrigsSrc = (ctx.TSRIGS_SRC ?: '').toString().trim()
+
+        if (!tsrigsSrc) {
+            error("TSRIGS_SRC is not defined for ${drvName}")
+        }
+
+        build = "${tsrigsSrc}/${build.replaceFirst('^\\./', '')}"
+    }
+
+    ctx.TE_IUT_NET_DRV_BUILD = build
+    ctx.env.TE_IUT_NET_DRV_BUILD = build
+}
+
+def checkoutDriverSources(ctx) {
+    def drvName = getDriverName(ctx)
+
+    if (!drvName) {
+        return
+    }
+
+    def componentId = ctx.teCommon.str2id(drvName).toLowerCase()
+    def varPrefix = "${componentId}_".toUpperCase()
+
+    if (ctx.TE_IUT_NET_DRV_SRC ?: ctx.env.TE_IUT_NET_DRV_SRC) {
+        return
+    }
+
+    def url = (ctx.params.net_drv_repo ?:
+               getDriverMetaValue(ctx, drvName, ['GIT_URL']) ?: '')
+              .toString().trim()
+    def revision = (ctx.params.net_drv_rev ?:
+                    getDriverMetaValue(ctx, drvName, ['REV', 'BRANCH']) ?: '')
+                   .toString().trim()
+
+    if (!url) {
+        error("Repository URL is not defined for ${drvName}")
+    }
+
+    if (!revision) {
+        error("Revision is not defined for ${drvName}")
+    }
+
+    ctx.teRun.generic_checkout(ctx: ctx,
+                               component: componentId,
+                               url: url,
+                               revision: revision,
+                               target: componentId,
+                               do_poll: false)
+
+    def srcVar = "${varPrefix}SRC"
+    if (ctx[srcVar]) {
+        ctx.TE_IUT_NET_DRV_SRC = ctx[srcVar]
+        ctx.env.TE_IUT_NET_DRV_SRC = ctx[srcVar]
+    } else {
+        error("Driver sources path is not defined for ${drvName}")
+    }
+}
+
+return this

--- a/jenkins/run
+++ b/jenkins/run
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 OKTET Labs Ltd. All rights reserved.
+// Copyright (C) 2023-2026 OKTET Labs Ltd. All rights reserved.
 //
 // Main pipeline for running tests.
 
@@ -9,6 +9,13 @@ teTsPipeline {
     specificParameters = [
         booleanParam(name: 'reuse_pco', defaultValue: true,
                      description: 'Reuse RPC server for different tests. It speeds up tests execution.'),
+        string(name: 'net_drv_name',
+               defaultValue: params.net_drv_name ?: '',
+               description: 'Driver name to use from loaded revisions. Optional.'),
+        string(name: 'net_drv_repo', defaultValue: '',
+               description: 'Network driver repository. Optional.'),
+        string(name: 'net_drv_rev', defaultValue: '',
+               description: 'Network driver revision. Optional.'),
     ]
 
     label = 'net-drv-ts'
@@ -17,6 +24,12 @@ teTsPipeline {
     tsconf = true
     publish_logs = true
     concurrent_builds = true
+
+    preRunHook = {
+        def netDrv = load("${teCtx.TS_SRC}/jenkins/net_drv.groovy")
+        netDrv.setDriverBuildScript(teCtx)
+        netDrv.checkoutDriverSources(teCtx)
+    }
 
     optionsProvider = {
         def opts = [

--- a/jenkins/update
+++ b/jenkins/update
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 OKTET Labs Ltd. All rights reserved.
+// Copyright (C) 2023-2026 OKTET Labs Ltd. All rights reserved.
 //
 // Pipeline to rebuild test suite after something changed in its
 // sources. This pipeline saves revisions in an artifact in case of
@@ -8,6 +8,16 @@
 @Library('teLib') _
 
 teTsPipeline {
+    specificParameters = [
+        string(name: 'net_drv_name',
+               defaultValue: params.net_drv_name ?: '',
+               description: 'Driver name to use from loaded revisions. Optional.'),
+        string(name: 'net_drv_repo', defaultValue: '',
+               description: 'Network driver repository. Optional.'),
+        string(name: 'net_drv_rev', defaultValue: '',
+               description: 'Network driver revision. Optional.'),
+    ]
+
     label = 'net-drv-ts'
     ts_name = 'net-drv-ts'
 
@@ -26,7 +36,19 @@ teTsPipeline {
         def triggers = [
             pollSCM('H * * * *'),
         ]
+
+        if (params.get_revs_from) {
+            // Rebuild update job when upstream revision source changes.
+            triggers += teCommon.jobs_triggers(params.get_revs_from)
+        }
+
         return triggers
+    }
+
+    preRunHook = {
+        def netDrv = load("${teCtx.TS_SRC}/jenkins/net_drv.groovy")
+        netDrv.setDriverBuildScript(teCtx)
+        netDrv.checkoutDriverSources(teCtx)
     }
 
     postRunHook = {


### PR DESCRIPTION
Add new logic to support using a driver from external sources in run/update pipelines. The user can now specify the driver sources directly in the pipeline parameters or retrieve this information from another Jenkins job.