### PR TITLE
lib: fix packet loss after MTU change

### DIFF
--- a/net-drv-ts/lib/net_drv_ts.c
+++ b/net-drv-ts/lib/net_drv_ts.c
@@ -611,6 +611,8 @@ net_drv_set_mtu(const char *ta, const char *if_name, int mtu,
     rc = tapi_cfg_base_if_set_mtu(ta, if_name, mtu, NULL);
     if (rc != 0)
         TEST_VERDICT("Failed to set MTU on %s, rc=%r", where, rc);
+
+    net_drv_wait_up_gen(ta, if_name, false);
 }
 
 /* See description in net_drv_ts.h */


### PR DESCRIPTION
Changing MTU may trigger a MAC/PHY restart, which can take some time. Make sure the link is ready after MTU changes.
