### PR TITLE
rss: fix TRC tag missuage

### DIFF
--- a/trc/rss.xml
+++ b/trc/rss.xml
@@ -12,7 +12,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
-        <results tags="max_rx_queues&lt;=1" key="NO-MQ">
+        <results tags="rx-queues&lt;=1" key="NO-MQ">
           <result value="SKIPPED">
             <verdict>There is no multiple Rx queues</verdict>
           </result>


### PR DESCRIPTION
NetDrv must use the rx-queues TRC tag instead of max_rx_queues. The rx-queues tag is the one added in the prologue.
