### PR TITLE
prologue: fix out-of-sync state after PHY changes

### DIFF
--- a/net-drv-ts/prologue.c
+++ b/net-drv-ts/prologue.c
@@ -339,6 +339,11 @@ main(int argc, char **argv)
     CHECK_RC(net_drv_set_phy_link(iut_rpcs->ta, iut_if->if_name));
     CHECK_RC(net_drv_set_phy_link(tst_rpcs->ta, tst_if->if_name));
 
+    TEST_STEP("Wait until link status becomes UP on both IUT and Tester.");
+    net_drv_wait_up_gen(iut_rpcs->ta, iut_if->if_name, false);
+    net_drv_wait_up_gen(tst_rpcs->ta, tst_if->if_name, false);
+
+    CHECK_RC(rc = cfg_synchronize("/:", TRUE));
     CHECK_RC(rc = cfg_tree_print(NULL, TE_LL_RING, "/:"));
 
     TEST_STEP("Collect and log TRC tags.");


### PR DESCRIPTION
PHY changes takes some time and may flip the link. Make sure that link is UP and PHY changes are synchronized in the Configurator tree.
