### PR TITLE
ethtool: detect TRC tags for missing ethtool opts

### DIFF
--- a/net-drv-ts/doc/dox_resources/tags.rst
+++ b/net-drv-ts/doc/dox_resources/tags.rst
@@ -59,3 +59,7 @@ List of tags set on various testing configurations to distinguish them.
     - peer-*DRIVER*
     - Name of the driver used on peer (aka Tester).
     - peer-i40e
+  *
+    - no-ethtool-opt-*
+    - ethtool CLI option is not present in `ethtool --help` output on IUT.
+    - no-ethtool-opt-show-fec

--- a/net-drv-ts/lib/net_drv_ethtool.c
+++ b/net-drv-ts/lib/net_drv_ethtool.c
@@ -9,13 +9,30 @@
  */
 
 #include "tapi_test.h"
+#include "tapi_rpc_stdio.h"
 #include "tapi_rpc_unistd.h"
+#include "tapi_tags.h"
 #include "tarpc.h"
 #include "net_drv_ethtool.h"
 
 #if HAVE_NET_IF_H
 #include <net/if.h>
 #endif
+
+#define NET_DRV_ETHTOOL_MISS_OPT_TAG_PREFIX "no-ethtool-opt-"
+
+/* CLI options used in TS tests to run ethtool. */
+static const char * const net_drv_ethtool_test_opts[] = {
+    "--statistics",
+    "--show-pause",
+    "--show-ring",
+    "--register-dump",
+    "--eeprom-dump",
+    "--dump-module-eeprom",
+    "--show-eee",
+    "--show-fec",
+    "--show-module",
+};
 
 /* See net_drv_ethtool.h */
 int
@@ -39,5 +56,80 @@ net_drv_ethtool_reset(rcf_rpc_server *rpcs, int s, const char *if_name,
     if (ret_flags != NULL)
         *ret_flags = ethtool_val.data;
 
+    return rc;
+}
+
+static te_errno
+net_drv_ethtool_get_help(rcf_rpc_server *rpcs, te_string *help)
+{
+    char *output[2] = { NULL, NULL };
+    rpc_wait_status status;
+    te_errno rc = 0;
+
+    rpcs->silent_pass = rpcs->silent_pass_default = true;
+
+    status = rpc_shell_get_all3(rpcs, output, "ethtool --help");
+    if (status.flag != RPC_WAIT_STATUS_EXITED || status.value != 0)
+    {
+        ERROR("ethtool --help terminated unexpectedly on TA %s (flag=%d, value=%d)",
+              rpcs->ta, status.flag, status.value);
+        rc = TE_EFAIL;
+        goto cleanup;
+    }
+
+    if (output[0] != NULL)
+        te_string_append(help, "%s", output[0]);
+
+    if (output[1] != NULL)
+        te_string_append(help, "%s", output[1]);
+
+cleanup:
+    free(output[0]);
+    free(output[1]);
+
+    rpcs->silent_pass = rpcs->silent_pass_default = false;
+
+    return rc;
+}
+
+/* See net_drv_ethtool.h */
+te_errno
+net_drv_add_missing_ethtool_opt_tags(rcf_rpc_server *rpcs)
+{
+    te_string help = TE_STRING_INIT;
+    te_string tag = TE_STRING_INIT;
+    const char *help_str;
+    const char *opt_name;
+    unsigned int i;
+    te_errno rc;
+
+    rc = net_drv_ethtool_get_help(rpcs, &help);
+    if (rc != 0)
+        goto cleanup;
+
+    help_str = te_string_value(&help);
+
+    for (i = 0; i < TE_ARRAY_LEN(net_drv_ethtool_test_opts); i++)
+    {
+        opt_name = net_drv_ethtool_test_opts[i];
+
+        if (strstr(help_str, opt_name) != NULL)
+            continue;
+
+        te_string_reset(&tag);
+        te_string_append(&tag, "%s%s", NET_DRV_ETHTOOL_MISS_OPT_TAG_PREFIX,
+                         opt_name + 2);
+
+        INFO("ethtool CLI option '%s' is not available, add TRC tag '%s'",
+             opt_name, te_string_value(&tag));
+
+        rc = tapi_tags_add_tag(te_string_value(&tag), NULL);
+        if (rc != 0)
+            goto cleanup;
+    }
+
+cleanup:
+    te_string_free(&tag);
+    te_string_free(&help);
     return rc;
 }

--- a/net-drv-ts/lib/net_drv_ethtool.h
+++ b/net-drv-ts/lib/net_drv_ethtool.h
@@ -57,4 +57,14 @@ extern int net_drv_ethtool_reset(rcf_rpc_server *rpcs, int s,
                                  unsigned int flags,
                                  unsigned int *ret_flags);
 
+/**
+ * Check whether CLI options used by TS tests are present in
+ * @b ethtool --help output and add proper TRC tags if some are missing.
+ *
+ * @param rpcs            RPC server.
+ *
+ * @return Status code.
+ */
+extern te_errno net_drv_add_missing_ethtool_opt_tags(rcf_rpc_server *rpcs);
+
 #endif /* !__TS_NET_DRV_ETHTOOL_H__ */

--- a/net-drv-ts/prologue.c
+++ b/net-drv-ts/prologue.c
@@ -350,6 +350,7 @@ main(int argc, char **argv)
     CHECK_RC(tapi_tags_add_linux_mm(iut_rpcs->ta, ""));
     CHECK_RC(add_driver_tag(iut_rpcs->ta, ""));
     CHECK_RC(add_driver_tag(tst_rpcs->ta, "peer-"));
+    CHECK_RC(net_drv_add_missing_ethtool_opt_tags(iut_rpcs));
     CHECK_RC(tapi_tags_add_firmwareversion_tag(iut_rpcs->ta,
                                                iut_if->if_name, ""));
     CHECK_RC(tapi_tags_add_net_pci_tags(iut_rpcs->ta, iut_if->if_name));

--- a/trc/ethtool.xml
+++ b/trc/ethtool.xml
@@ -425,6 +425,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="no-ethtool-opt-dump-module-eeprom" key="NO-ETHTOOL-OPT" notes="unknown option for ethtool">
+          <result value="FAILED">
+            <verdict>tapi_ethtool() returned unexpected error</verdict>
+          </result>
+        </results>
         <results tags="virtio-pci" key="NO-MODULE-EEPROM-DUMP" notes="virtio does support module EEPROM dump">
           <result value="FAILED">
             <verdict>Ethtool command did not terminate successfully</verdict>
@@ -472,6 +477,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="no-ethtool-opt-show-fec" key="NO-ETHTOOL-OPT" notes="unknown option for ethtool">
+          <result value="FAILED">
+            <verdict>Failed to process ethtool command</verdict>
+          </result>
+        </results>
         <results tags="sfc" key="NO-ETHTOOL-FEC">
           <result value="SKIPPED">
             <verdict>Ethtool command is not supported</verdict>
@@ -490,6 +500,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="no-ethtool-opt-show-module" key="NO-ETHTOOL-OPT" notes="unknown option for ethtool">
+          <result value="FAILED">
+            <verdict>Failed to process ethtool command</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="eee" type="script">


### PR DESCRIPTION
Implemented API to check ehtool options that may be missing in ethtool. If an option is missing, add a proper TRC tag.