### PR TITLE
perf/tcp_udp_perf: improve generic expectations

### DIFF
--- a/net-drv-ts/doc/dox_resources/tags.rst
+++ b/net-drv-ts/doc/dox_resources/tags.rst
@@ -63,3 +63,8 @@ List of tags set on various testing configurations to distinguish them.
     - no-ethtool-opt-*
     - ethtool CLI option is not present in `ethtool --help` output on IUT.
     - no-ethtool-opt-show-fec
+  *
+    - *SIDE*-cpus:*VALUE*
+    - Number of CPUs on IUT or Tester side.
+      May be used for comparison: greater, equal, less.
+    - iut-cpus:2

--- a/net-drv-ts/perf/tcp_udp_perf.c
+++ b/net-drv-ts/perf/tcp_udp_perf.c
@@ -620,8 +620,11 @@ main(int argc, char *argv[])
 
         rc = tapi_cfg_cpu_grab_by_prop(server_rpcs->ta, NULL, &cpu_id);
         if (rc != 0 && rc == TE_RC(TE_TAPI, TE_ENOENT))
-            TEST_SKIP("%d/%d CPUs are available for servers",
-                      i, n_perf_insts * n_ports);
+        {
+            WARN("%d/%d CPUs are available for servers",
+                 i, n_perf_insts * n_ports);
+            TEST_SKIP("Too few CPUs are available for perf instances");
+        }
         CHECK_RC(rc);
 
         free(server_addr_str);
@@ -647,7 +650,10 @@ main(int argc, char *argv[])
 
         rc = tapi_cfg_cpu_grab_by_prop(client_rpcs->ta, NULL, &cpu_id);
         if (rc != 0 && rc == TE_RC(TE_TAPI, TE_ENOENT))
-            TEST_SKIP("%d/%d CPUs are available for clients", i, n_perf_insts);
+        {
+            WARN("%d/%d CPUs are available for clients", i, n_perf_insts);
+            TEST_SKIP("Too few CPUs are available for perf instances");
+        }
         CHECK_RC(rc);
 
         perf_clients[i] = tapi_perf_client_create(perf_bench, &perf_opts,

--- a/net-drv-ts/perf/tcp_udp_perf.c
+++ b/net-drv-ts/perf/tcp_udp_perf.c
@@ -619,7 +619,7 @@ main(int argc, char *argv[])
         const struct sockaddr *client_addr = client_addrs[i / n_perf_insts];
 
         rc = tapi_cfg_cpu_grab_by_prop(server_rpcs->ta, NULL, &cpu_id);
-        if (rc != 0 && rc == TE_RC(TE_TAPI, TE_ENOENT))
+        if (rc == TE_RC(TE_TAPI, TE_ENOENT))
         {
             WARN("%d/%d CPUs are available for servers",
                  i, n_perf_insts * n_ports);
@@ -649,7 +649,7 @@ main(int argc, char *argv[])
         CHECK_RC(tapi_perf_server_start_unreliable(perf_servers[i]));
 
         rc = tapi_cfg_cpu_grab_by_prop(client_rpcs->ta, NULL, &cpu_id);
-        if (rc != 0 && rc == TE_RC(TE_TAPI, TE_ENOENT))
+        if (rc == TE_RC(TE_TAPI, TE_ENOENT))
         {
             WARN("%d/%d CPUs are available for clients", i, n_perf_insts);
             TEST_SKIP("Too few CPUs are available for perf instances");

--- a/net-drv-ts/prologue.c
+++ b/net-drv-ts/prologue.c
@@ -27,6 +27,7 @@
 #include "tapi_cfg_net.h"
 #include "tapi_cfg_modules.h"
 #include "tapi_cfg_pci.h"
+#include "tapi_cfg_cpu.h"
 #include "tapi_sh_env.h"
 #include "tapi_cfg_pci.h"
 #include "tapi_reqs.h"
@@ -246,6 +247,26 @@ prepare_ipv6(void)
     }
 }
 
+static void
+add_cpus_tag(const char *ta, const char *prefix)
+{
+    te_string tag_name = TE_STRING_INIT;
+    te_string tag_val = TE_STRING_INIT;
+    size_t cpus;
+
+    te_string_reset(&tag_name);
+    te_string_append(&tag_name, "%s-cpus", prefix);
+
+    CHECK_RC(tapi_cfg_get_all_threads(ta, &cpus, NULL));
+    te_string_reset(&tag_val);
+    te_string_append(&tag_val, "%zu", cpus);
+    CHECK_RC(tapi_tags_add_tag(te_string_value(&tag_name),
+                               te_string_value(&tag_val)));
+
+    te_string_free(&tag_name);
+    te_string_free(&tag_val);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -374,6 +395,9 @@ main(int argc, char **argv)
     te_string_reset(&str);
     te_string_append(&str, "%d", combined_max);
     CHECK_RC(tapi_tags_add_tag("max-combined-channels", te_string_value(&str)));
+
+    add_cpus_tag(iut_rpcs->ta, "iut");
+    add_cpus_tag(tst_rpcs->ta, "tst");
 
     TEST_SUCCESS;
 

--- a/trc/perf.xml
+++ b/trc/perf.xml
@@ -40,7 +40,7 @@
         <arg name="perf_bench"/>
         <arg name="dual_mode"/>
         <arg name="protocol"/>
-        <arg name="n_perf_insts"/>
+        <arg name="n_perf_insts">1</arg>
         <arg name="n_streams"/>
         <arg name="bandwidth"/>
         <arg name="rx_csum"/>
@@ -56,6 +56,60 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="perf_bench"/>
+        <arg name="dual_mode"/>
+        <arg name="protocol"/>
+        <arg name="n_perf_insts">2</arg>
+        <arg name="n_streams"/>
+        <arg name="bandwidth"/>
+        <arg name="rx_csum"/>
+        <arg name="rx_gro"/>
+        <arg name="rx_vlan_strip"/>
+        <arg name="tx_csum"/>
+        <arg name="tx_gso"/>
+        <arg name="tso"/>
+        <arg name="tx_vlan_insert"/>
+        <arg name="rx_coalesce_usecs"/>
+        <arg name="rx_max_coalesced_frames"/>
+        <arg name="rx_ring"/>
+        <arg name="tx_ring"/>
+        <arg name="channels"/>
+        <notes/>
+        <results tags="iut-cpus&lt;2|tst-cpus&lt;2" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="perf_bench"/>
+        <arg name="dual_mode"/>
+        <arg name="protocol"/>
+        <arg name="n_perf_insts">4</arg>
+        <arg name="n_streams"/>
+        <arg name="bandwidth"/>
+        <arg name="rx_csum"/>
+        <arg name="rx_gro"/>
+        <arg name="rx_vlan_strip"/>
+        <arg name="tx_csum"/>
+        <arg name="tx_gso"/>
+        <arg name="tso"/>
+        <arg name="tx_vlan_insert"/>
+        <arg name="rx_coalesce_usecs"/>
+        <arg name="rx_max_coalesced_frames"/>
+        <arg name="rx_ring"/>
+        <arg name="tx_ring"/>
+        <arg name="channels"/>
+        <notes/>
+        <results tags="iut-cpus&lt;4|tst-cpus&lt;4" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="udp_perf2" type="script">
@@ -92,7 +146,7 @@
         <arg name="perf_bench"/>
         <arg name="dual_mode"/>
         <arg name="protocol"/>
-        <arg name="n_perf_insts"/>
+        <arg name="n_perf_insts">1</arg>
         <arg name="n_streams"/>
         <arg name="bandwidth"/>
         <arg name="rx_csum"/>
@@ -108,6 +162,60 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="perf_bench"/>
+        <arg name="dual_mode"/>
+        <arg name="protocol"/>
+        <arg name="n_perf_insts">2</arg>
+        <arg name="n_streams"/>
+        <arg name="bandwidth"/>
+        <arg name="rx_csum"/>
+        <arg name="rx_gro"/>
+        <arg name="rx_vlan_strip"/>
+        <arg name="tx_csum"/>
+        <arg name="tx_gso"/>
+        <arg name="tso"/>
+        <arg name="tx_vlan_insert"/>
+        <arg name="rx_coalesce_usecs"/>
+        <arg name="rx_max_coalesced_frames"/>
+        <arg name="rx_ring"/>
+        <arg name="tx_ring"/>
+        <arg name="channels"/>
+        <notes/>
+        <results tags="iut-cpus&lt;2|tst-cpus&lt;2" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="perf_bench"/>
+        <arg name="dual_mode"/>
+        <arg name="protocol"/>
+        <arg name="n_perf_insts">4</arg>
+        <arg name="n_streams"/>
+        <arg name="bandwidth"/>
+        <arg name="rx_csum"/>
+        <arg name="rx_gro"/>
+        <arg name="rx_vlan_strip"/>
+        <arg name="tx_csum"/>
+        <arg name="tx_gso"/>
+        <arg name="tso"/>
+        <arg name="tx_vlan_insert"/>
+        <arg name="rx_coalesce_usecs"/>
+        <arg name="rx_max_coalesced_frames"/>
+        <arg name="rx_ring"/>
+        <arg name="tx_ring"/>
+        <arg name="channels"/>
+        <notes/>
+        <results tags="iut-cpus&lt;4|tst-cpus&lt;4" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tcp_perf3_rx_offloads" type="script">
@@ -264,6 +372,11 @@
         <arg name="tx_ring"/>
         <arg name="channels">1</arg>
         <notes/>
+        <results tags="iut-cpus&lt;4|tst-cpus&lt;4" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -291,6 +404,11 @@
             <verdict>Failed to set number of combined channels: TA_UNIX-EINVAL</verdict>
           </result>
         </results>
+        <results tags="(iut-cpus&lt;4|tst-cpus&lt;4)&amp;max-combined-channels&gt;=2" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -316,6 +434,11 @@
         <results tags="max-combined-channels&lt;4" key="TOO-FEW-COMBINED-CHANNELS">
           <result value="FAILED">
             <verdict>Failed to set number of combined channels: TA_UNIX-EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="(iut-cpus&lt;4|tst-cpus&lt;4)&amp;max-combined-channels&gt;=4" key="TOO-FEW-CPU">
+          <result value="SKIPPED">
+            <verdict>Too few CPUs are available for perf instances</verdict>
           </result>
         </results>
       </iter>

--- a/trc/perf.xml
+++ b/trc/perf.xml
@@ -467,6 +467,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="udp_perf3_dual_port_bidir" type="script">
@@ -493,6 +498,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tcp_perf3_dual_port_scaling" type="script">
@@ -519,6 +529,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tcp_perf3_dual_port_offloads" type="script">
@@ -545,6 +560,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="fwd_prologue" type="script">
@@ -553,6 +573,11 @@
       <iter result="PASSED">
         <arg name="env"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tcp_perf3_fwd_basic" type="script">
@@ -579,6 +604,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="udp_perf3_fwd_basic" type="script">
@@ -605,6 +635,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tcp_perf3_fwd_bidir" type="script">
@@ -631,6 +666,11 @@
         <arg name="tx_ring"/>
         <arg name="channels"/>
         <notes/>
+        <results tags="parallel-links&lt;2" key="FEW-PARALLEL-LINKS">
+          <result value="FAILED">
+            <verdict>Cannot bind env</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>


### PR DESCRIPTION
- respect CPU limitations in perf results
- remove useless return code check
- add expectations for missing second link