### PR TITLE
basic/set_rx_headroom: fix false fails with no TUN support

### DIFF
--- a/net-drv-ts/basic/set_rx_headroom.c
+++ b/net-drv-ts/basic/set_rx_headroom.c
@@ -165,7 +165,14 @@ main(int argc, char *argv[])
         RING_VERDICT("Failed to enable all flags in msglvl");
 
     TEST_STEP("Create TAP interface on IUT.");
-    CHECK_RC(tapi_cfg_tap_add(iut_rpcs->ta, TAP_NAME));
+    rc = tapi_cfg_tap_add(iut_rpcs->ta, TAP_NAME);
+    if (TE_RC_GET_ERROR(rc) == TE_ENOENT ||
+        TE_RC_GET_ERROR(rc) == RPC_ENODEV ||
+        TE_RC_GET_ERROR(rc) == RPC_EOPNOTSUPP)
+    {
+        TEST_SKIP("TUN/TAP is unavailable");
+    }
+    CHECK_RC(rc);
     CHECK_RC(tapi_cfg_base_if_up(iut_rpcs->ta, TAP_NAME));
 
     CFG_WAIT_CHANGES;

--- a/net-drv-ts/doc/dox_resources/tags.rst
+++ b/net-drv-ts/doc/dox_resources/tags.rst
@@ -64,6 +64,10 @@ List of tags set on various testing configurations to distinguish them.
     - ethtool CLI option is not present in `ethtool --help` output on IUT.
     - no-ethtool-opt-show-fec
   *
+    - *SIDE*-no-tun
+    - TUN support is unavailable on IUT or Tester (`/dev/net/tun` cannot be opened on the corresponding side).
+    - iut-no-tun
+  *
     - *SIDE*-cpus:*VALUE*
     - Number of CPUs on IUT or Tester side.
       May be used for comparison: greater, equal, less.

--- a/net-drv-ts/prologue.c
+++ b/net-drv-ts/prologue.c
@@ -30,6 +30,7 @@
 #include "tapi_cfg_cpu.h"
 #include "tapi_sh_env.h"
 #include "tapi_cfg_pci.h"
+#include "tapi_rpc_unistd.h"
 #include "tapi_reqs.h"
 #include "tapi_tags.h"
 
@@ -169,6 +170,37 @@ get_phy_local_param(const char *ta, const char *param, char **value)
     }
 
     return 0;
+}
+
+static te_errno
+add_tun_support_tag(rcf_rpc_server *rpcs, const char *prefix)
+{
+    te_errno rc;
+    te_string tag = TE_STRING_INIT_STATIC(DEF_STR_LEN);
+    int fd;
+
+    RPC_AWAIT_ERROR(rpcs);
+    fd = rpc_open(rpcs, "/dev/net/tun", RPC_O_RDWR, 0);
+    if (fd >= 0)
+    {
+        RPC_CLOSE(rpcs, fd);
+        return 0;
+    }
+
+    rc = RPC_ERRNO(rpcs);
+    if (rc == RPC_ENOENT || rc == RPC_ENODEV || rc == RPC_EOPNOTSUPP)
+    {
+        INFO("TUN/TAP is not available on TA %s", rpcs->ta);
+        te_string_append(&tag, "%sno-tun", prefix);
+        rc = tapi_tags_add_tag(te_string_value(&tag), NULL);
+        if (rc != 0)
+            return rc;
+
+        return 0;
+    }
+
+    ERROR("Failed to check TUN/TAP support on TA %s: %r", rpcs->ta, rc);
+    return rc;
 }
 
 static void
@@ -371,6 +403,8 @@ main(int argc, char **argv)
     CHECK_RC(tapi_tags_add_linux_mm(iut_rpcs->ta, ""));
     CHECK_RC(add_driver_tag(iut_rpcs->ta, ""));
     CHECK_RC(add_driver_tag(tst_rpcs->ta, "peer-"));
+    CHECK_RC(add_tun_support_tag(iut_rpcs, "iut-"));
+    CHECK_RC(add_tun_support_tag(tst_rpcs, "tst-"));
     CHECK_RC(net_drv_add_missing_ethtool_opt_tags(iut_rpcs));
     CHECK_RC(tapi_tags_add_firmwareversion_tag(iut_rpcs->ta,
                                                iut_if->if_name, ""));

--- a/trc/basic.xml
+++ b/trc/basic.xml
@@ -825,6 +825,11 @@
             <verdict>Failed to enable all flags in msglvl</verdict>
           </result>
         </results>
+        <results tags="iut-no-tun" key="NO-TUN">
+          <result value="SKIPPED">
+            <verdict>TUN/TAP is unavailable</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>


### PR DESCRIPTION
The test expects TUN support, which may be unavailable. Handle this case properly and update the TRC expectations accordingly.